### PR TITLE
Update custom.css - button alignments and scroll-margin-top setting

### DIFF
--- a/www/templates/joomla/css/custom.css
+++ b/www/templates/joomla/css/custom.css
@@ -60,6 +60,36 @@ Added: 2020-04-20 - Mark Lee / WilcoA
 	margin-top: 30px;
 }
 
+/* 
+Added 2021-03-19 - Mark Lee / WilcoA (PR raised by Patrick Jackson)
+Aligns continue reading buttons across the issue category view
+*/
+#eb .eb-mag-grids__item > div {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+#eb .eb-mag .eb-mag-body {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+}
+#eb .eb-mag .eb-mag-body p {
+    flex-grow: 1;
+}
+
+#eb .eb-mag .eb-mag-body p:empty {
+    display: none;
+}
+
+/* 
+Added Patrick Jackson 2021-03-10
+Pushes heading down when page scrolls so it's not hidden below the page header.
+*/
+#eb .eb-anchor-link {
+    scroll-margin-top: 60px;
+}
+
 /* Sticky Progress bar
 Added: 2020-06-21 - Mark Lee / WilcoA
 */


### PR DESCRIPTION
Adding css proposed by Mark Lee and Easyblog developers to align buttons (per Glip 2021-03-08)

![image](https://user-images.githubusercontent.com/5515866/110484512-d36ca400-813e-11eb-86e3-4c8b250cd594.png)

Also adding scroll-padding-top value for when you click on comments - this scrolls to 50px from the top of the page so you see the heading instead of the heading being under the header and menu area.

To test, click on Comments link at the top of an article. Page will scroll to comments heading

Before
![image](https://user-images.githubusercontent.com/5515866/110484621-f008dc00-813e-11eb-98a6-5df307d15688.png)

After
![image](https://user-images.githubusercontent.com/5515866/110484996-4d049200-813f-11eb-8608-174359905ed7.png)
