### PR TITLE
Various changes to improve magazine styling

### DIFF
--- a/www/templates/joomla/css/custom.css
+++ b/www/templates/joomla/css/custom.css
@@ -182,6 +182,31 @@ a {
     #eb .eb-blog-grid__item { /* Displays flex columns at single column on mobile vs 3 columns */
         flex: 0 0 100%;
     }
+  
+    .eb-entry-body {
+        padding: 0;
+    }
+    
+    #eb .eb-post-thumb .eb-post-image img {
+	    max-width: 100%;
+      width: 100%;
+    }
+    .eb-entry-body .eb-image.eb-post-thumb {
+      margin: auto;
+    }
+    .eb-entry-head {
+	    padding: 20px 0px;
+    }
+    #eb h1 {
+	    color: #2E3657;
+	    font-size: 1.6rem;
+    }
+    .es-post-state {
+      padding: 0px 35px;
+    }
+    #eb h2, #eb h3, #eb h4, #eb h5, #eb h6 {
+      margin: 30px 0 20px;
+    }
 } /* End mobile styles */
 
 
@@ -450,7 +475,11 @@ body #eb .eb-mag-grids .magazine-btn-more {
     align-self: baseline
   }
 }
-@media(min-width: 768px) {
+@media(min-width: 768px) { /* Desktop Styles */
+  #eb .eb-post-thumb .eb-post-image img {
+	  max-width: calc(100% + 200px);
+    width: calc(100% + 200px);
+  }
   .d-md-none {
     display: none;
   }

--- a/www/templates/joomla/css/custom.css
+++ b/www/templates/joomla/css/custom.css
@@ -1,65 +1,63 @@
 /* EasyBlog - General Style Overrides*/
 div#eb {
-    clear: both;
+  clear: both;
 }
-
-#eb.st-5 .eb-gallery-body {background: rgba(255,255,255,0.8)!important}
-#eb.st-5 .eb-gallery-body .eb-gallery-content{color:#444!important}
+#eb.st-5 .eb-gallery-body {
+  background: rgba(255, 255, 255, 0.8) !important
+}
+#eb.st-5 .eb-gallery-body .eb-gallery-content {
+  color: #444 !important
+}
 .onefield.fieldacyterms label {
-    font-size: 85%;
+  font-size: 85%;
 }
-
-.subnav .nav-pills {float: left;}
+.subnav .nav-pills {
+  float: left;
+}
 .mod-languages.pull-right {
-    padding-top: 10px;
+  padding-top: 10px;
 }
 #eb.eb-mod .eb-gallery-title a {
-    color: #08c!important;
+  color: #08c !important;
 }
-
 .com_easyblog .container.main a {
-	color: #437DC2;
+  color: #437DC2;
 }
 .container.main {
-	border-radius: 0;
-	border: none;
-	border-top: 1px solid #ddd;
-	padding: 40px;
+  border-radius: 0;
+  border: none;
+  border-top: 1px solid #ddd;
+  padding: 40px;
 }
 .com_easyblog aside {
-	padding-top: 0;
+  padding-top: 0;
 }
 .subnav {
-	box-shadow: none;
+  box-shadow: none;
 }
-
 /* templates/joomla/html/com_easyblog/blogs/latest/card/default.php*/
 #eb .eb-card {
-	box-shadow: none;
+  box-shadow: none;
 }
 #eb .eb-cards--2 .eb-cards__item {
-	padding: 0 16px 16px;
+  padding: 0 16px 16px;
 }
-#eb .eb-card__bd,
-#eb .eb-card__ft {
-	padding: 16px 0;
+#eb .eb-card__bd, #eb .eb-card__ft {
+  padding: 16px 0;
 }
 #eb .eb-cards--2 {
-	margin-left: -16px;
-	margin-right: -16px;
+  margin-left: -16px;
+  margin-right: -16px;
 }
-
 /* Blog Magazine
 Added: 2020-04-20 - Mark Lee / WilcoA
 */
 #eb .eb-mag.eb-mag-list .eb-more {
-	margin-top: 30px;	
+  margin-top: 30px;
 }
-
 #eb .eb-mag-table + .eb-mag-table {
-	margin-top: 30px;
+  margin-top: 30px;
 }
-
 /* 
 Added 2021-03-19 - Mark Lee / WilcoA (PR raised by Patrick Jackson)
 Aligns continue reading buttons across the issue category view
@@ -75,11 +73,10 @@ Aligns continue reading buttons across the issue category view
   flex-direction: column;
 }
 #eb .eb-mag .eb-mag-body p {
-    flex-grow: 1;
+  flex-grow: 1;
 }
-
 #eb .eb-mag .eb-mag-body p:empty {
-    display: none;
+  display: none;
 }
 
 #eb .eb-mag-grids .eb-mag-blog-image, #eb .eb-blog-grid-image {
@@ -193,1647 +190,1847 @@ Added Patrick Jackson 2021-03-10
 Pushes heading down when page scrolls so it's not hidden below the page header.
 */
 #eb .eb-anchor-link {
-    scroll-margin-top: 60px;
+  scroll-margin-top: 60px;
 }
-
 /* Sticky Progress bar
 Added: 2020-06-21 - Mark Lee / WilcoA
 */
-body #eb .eb-reading-progress,
-body #eb .eb-reading-progress-sticky {
-	top: 80px !important;
+body #eb .eb-reading-progress, body #eb .eb-reading-progress-sticky {
+  top: 80px !important;
 }
-
-body #eb.is-mobile .eb-reading-progress,
-body #eb.is-mobile .eb-reading-progress-sticky {
-	top: 0px !important;
+body #eb.is-mobile .eb-reading-progress, body #eb.is-mobile .eb-reading-progress-sticky {
+  top: 0px !important;
 }
-
 /*blog navigation*/
 #eb.mod_toolbar {
-	position: relative;
-	z-index: 2;
-	background: #F4F6F7;
+  position: relative;
+  z-index: 2;
+  background: #F4F6F7;
 }
-
 #eb-canvas.mm-menu_offcanvas {
-	width: 80vw;
-	z-index: 2;
+  width: 80vw;
+  z-index: 2;
 }
-
-/* 	mod_easybloglatestblogs
-	Lower View All Button
+/*     mod_easybloglatestblogs
+    Lower View All Button
 */
 .view-all-blogs {
-    padding-top: 40px;
+  padding-top: 40px;
 }
 /* Homepage layout */
 body #eb .eb-mag-blog-image {
-    background-size: contain;
+  background-size: contain;
 }
-
 body #eb .eb-mag-grids .magazine-btn-more {
-	display: block;
-	text-align: center;
+  display: block;
+  text-align: center;
 }
 /* End - EasBlog */
-
 /* None Joomla / Extensions Specific things */
 /* Flexbox */
-.d-none  { display: none; }
-.d-block  { display: block; }
-.d-inline-block  { display: inline-block; }
-.d-flex  { display: flex; }
-.d-inline-flex { display: inline-flex; }
-
+.d-none {
+  display: none;
+}
+.d-block {
+  display: block;
+}
+.d-inline-block {
+  display: inline-block;
+}
+.d-flex {
+  display: flex;
+}
+.d-inline-flex {
+  display: inline-flex;
+}
 /* Flex direction */
-.flex-direction--r  { flex-direction: row; } /* Default */
-.flex-direction--rr { flex-direction: row-reverse; }
-.flex-direction--c  { flex-direction: column; }
-.flex-direction--cr { flex-direction: column-reverse; }
-
-
+.flex-direction--r {
+  flex-direction: row;
+} /* Default */
+.flex-direction--rr {
+  flex-direction: row-reverse;
+}
+.flex-direction--c {
+  flex-direction: column;
+}
+.flex-direction--cr {
+  flex-direction: column-reverse;
+}
 /* Flex wrap */
-.flex-wrap--n  { flex-wrap: nowrap; } /* Default */
-.flex-wrap--w  { flex-wrap: wrap; }
-.flex-wrap--wr { flex-wrap: wrap-reverse; }
-
-
+.flex-wrap--n {
+  flex-wrap: nowrap;
+} /* Default */
+.flex-wrap--w {
+  flex-wrap: wrap;
+}
+.flex-wrap--wr {
+  flex-wrap: wrap-reverse;
+}
 /* Justify content */
-.justify-content--fe { justify-content: flex-end; }
-.justify-content--fs { justify-content: flex-start; } /* Default */
-.justify-content--c  { justify-content: center; }
-.justify-content--sa { justify-content: space-around; }
-.justify-content--sb { justify-content: space-between; }
-
-
+.justify-content--fe {
+  justify-content: flex-end;
+}
+.justify-content--fs {
+  justify-content: flex-start;
+} /* Default */
+.justify-content--c {
+  justify-content: center;
+}
+.justify-content--sa {
+  justify-content: space-around;
+}
+.justify-content--sb {
+  justify-content: space-between;
+}
 /* Align items */
-.align-items--fs { align-items: flex-start; }
-.align-items--c  { align-items: center; }
-.align-items--fe { align-items: flex-end; }
-.align-items--s  { align-items: stretch; } /* Default */
-.align-items--b  { align-items: baseline; }
-
-
+.align-items--fs {
+  align-items: flex-start;
+}
+.align-items--c {
+  align-items: center;
+}
+.align-items--fe {
+  align-items: flex-end;
+}
+.align-items--s {
+  align-items: stretch;
+} /* Default */
+.align-items--b {
+  align-items: baseline;
+}
 /* Flex grow */
-.flex-grow--0 { flex-grow: 0; } /* Default */
-.flex-grow--1 { flex-grow: 1; }
-
-
+.flex-grow--0 {
+  flex-grow: 0;
+} /* Default */
+.flex-grow--1 {
+  flex-grow: 1;
+}
 /* Flex shrink */
-.flex-shrink--0 { flex-shrink: 0; }
-.flex-shrink--1 { flex-shrink: 1; } /* Default */
-
-
+.flex-shrink--0 {
+  flex-shrink: 0;
+}
+.flex-shrink--1 {
+  flex-shrink: 1;
+} /* Default */
 /* Flex basis */
-.flex-basis--a { flex-basis: auto; } /* Default */
-.flex-basis--0 { flex-basis: 0; }
-
-
+.flex-basis--a {
+  flex-basis: auto;
+} /* Default */
+.flex-basis--0 {
+  flex-basis: 0;
+}
 /* Align self */
-.align-self--a  { align-self: auto; } /* Default */
-.align-self--fs { align-self: flex-start; }
-.align-self--c  { align-self: center; }
-.align-self--fe { align-self: flex-end; }
-.align-self--s  { align-self: stretch; }
-.align-self--b  { align-self: baseline }
-
+.align-self--a {
+  align-self: auto;
+} /* Default */
+.align-self--fs {
+  align-self: flex-start;
+}
+.align-self--c {
+  align-self: center;
+}
+.align-self--fe {
+  align-self: flex-end;
+}
+.align-self--s {
+  align-self: stretch;
+}
+.align-self--b {
+  align-self: baseline
+}
 @media(min-width: 576px) {
-	.d-sm-none  { display: none; }
-	.d-sm-block  { display: block; }
-	.d-sm-inline-block  { display: inline-block; }
-	.d-sm-flex  { display: flex; }
-	.d-sm-inline-flex { display: inline-flex; }
-
-	/* Flex direction */
-	.flex-direction-sm--r  { flex-direction: row; } /* Default */
-	.flex-direction-sm--rr { flex-direction: row-reverse; }
-	.flex-direction-sm--c  { flex-direction: column; }
-	.flex-direction-sm--cr { flex-direction: column-reverse; }
-
-
-	/* Flex wrap */
-	.flex-wrap-sm--n  { flex-wrap: nowrap; } /* Default */
-	.flex-wrap-sm--w  { flex-wrap: wrap; }
-	.flex-wrap-sm--wr { flex-wrap: wrap-reverse; }
-
-
-	/* Justify content */
-	.justify-content-sm--fe { justify-content: flex-end; }
-	.justify-content-sm--fs { justify-content: flex-start; } /* Default */
-	.justify-content-sm--c  { justify-content: center; }
-	.justify-content-sm--sa { justify-content: space-around; }
-	.justify-content-sm--sb { justify-content: space-between; }
-
-
-	/* Align items */
-	.align-items-sm--fs { align-items: flex-start; }
-	.align-items-sm--c  { align-items: center; }
-	.align-items-sm--fe { align-items: flex-end; }
-	.align-items-sm--s  { align-items: stretch; } /* Default */
-	.align-items-sm--b  { align-items: baseline; }
-
-
-	/* Flex grow */
-	.flex-grow-sm--0 { flex-grow: 0; } /* Default */
-	.flex-grow-sm--1 { flex-grow: 1; }
-
-
-	/* Flex shrink */
-	.flex-shrink-sm--0 { flex-shrink: 0; }
-	.flex-shrink-sm--1 { flex-shrink: 1; } /* Default */
-
-
-	/* Flex basis */
-	.flex-basis-sm--a { flex-basis: auto; } /* Default */
-	.flex-basis-sm--0 { flex-basis: 0; }
-
-
-	/* Align self */
-	.align-self-sm--a  { align-self: auto; } /* Default */
-	.align-self-sm--fs { align-self: flex-start; }
-	.align-self-sm--c  { align-self: center; }
-	.align-self-sm--fe { align-self: flex-end; }
-	.align-self-sm--s  { align-self: stretch; }
-	.align-self-sm--b  { align-self: baseline }
+  .d-sm-none {
+    display: none;
+  }
+  .d-sm-block {
+    display: block;
+  }
+  .d-sm-inline-block {
+    display: inline-block;
+  }
+  .d-sm-flex {
+    display: flex;
+  }
+  .d-sm-inline-flex {
+    display: inline-flex;
+  }
+  /* Flex direction */
+  .flex-direction-sm--r {
+    flex-direction: row;
+  } /* Default */
+  .flex-direction-sm--rr {
+    flex-direction: row-reverse;
+  }
+  .flex-direction-sm--c {
+    flex-direction: column;
+  }
+  .flex-direction-sm--cr {
+    flex-direction: column-reverse;
+  }
+  /* Flex wrap */
+  .flex-wrap-sm--n {
+    flex-wrap: nowrap;
+  } /* Default */
+  .flex-wrap-sm--w {
+    flex-wrap: wrap;
+  }
+  .flex-wrap-sm--wr {
+    flex-wrap: wrap-reverse;
+  }
+  /* Justify content */
+  .justify-content-sm--fe {
+    justify-content: flex-end;
+  }
+  .justify-content-sm--fs {
+    justify-content: flex-start;
+  } /* Default */
+  .justify-content-sm--c {
+    justify-content: center;
+  }
+  .justify-content-sm--sa {
+    justify-content: space-around;
+  }
+  .justify-content-sm--sb {
+    justify-content: space-between;
+  }
+  /* Align items */
+  .align-items-sm--fs {
+    align-items: flex-start;
+  }
+  .align-items-sm--c {
+    align-items: center;
+  }
+  .align-items-sm--fe {
+    align-items: flex-end;
+  }
+  .align-items-sm--s {
+    align-items: stretch;
+  } /* Default */
+  .align-items-sm--b {
+    align-items: baseline;
+  }
+  /* Flex grow */
+  .flex-grow-sm--0 {
+    flex-grow: 0;
+  } /* Default */
+  .flex-grow-sm--1 {
+    flex-grow: 1;
+  }
+  /* Flex shrink */
+  .flex-shrink-sm--0 {
+    flex-shrink: 0;
+  }
+  .flex-shrink-sm--1 {
+    flex-shrink: 1;
+  } /* Default */
+  /* Flex basis */
+  .flex-basis-sm--a {
+    flex-basis: auto;
+  } /* Default */
+  .flex-basis-sm--0 {
+    flex-basis: 0;
+  }
+  /* Align self */
+  .align-self-sm--a {
+    align-self: auto;
+  } /* Default */
+  .align-self-sm--fs {
+    align-self: flex-start;
+  }
+  .align-self-sm--c {
+    align-self: center;
+  }
+  .align-self-sm--fe {
+    align-self: flex-end;
+  }
+  .align-self-sm--s {
+    align-self: stretch;
+  }
+  .align-self-sm--b {
+    align-self: baseline
+  }
 }
-
 @media(min-width: 768px) {
-	.d-md-none  { display: none; }
-	.d-md-block  { display: block; }
-	.d-md-inline-block  { display: inline-block; }
-	.d-md-flex  { display: flex; }
-	.d-md-inline-flex { display: inline-flex; }
-
-	/* Flex direction */
-	.flex-direction-md--r  { flex-direction: row; } /* Default */
-	.flex-direction-md--rr { flex-direction: row-reverse; }
-	.flex-direction-md--c  { flex-direction: column; }
-	.flex-direction-md--cr { flex-direction: column-reverse; }
-
-
-	/* Flex wrap */
-	.flex-wrap-md--n  { flex-wrap: nowrap; } /* Default */
-	.flex-wrap-md--w  { flex-wrap: wrap; }
-	.flex-wrap-md--wr { flex-wrap: wrap-reverse; }
-
-
-	/* Justify content */
-	.justify-content-md--fe { justify-content: flex-end; }
-	.justify-content-md--fs { justify-content: flex-start; } /* Default */
-	.justify-content-md--c  { justify-content: center; }
-	.justify-content-md--sa { justify-content: space-around; }
-	.justify-content-md--sb { justify-content: space-between; }
-
-
-	/* Align items */
-	.align-items-md--fs { align-items: flex-start; }
-	.align-items-md--c  { align-items: center; }
-	.align-items-md--fe { align-items: flex-end; }
-	.align-items-md--s  { align-items: stretch; } /* Default */
-	.align-items-md--b  { align-items: baseline; }
-
-
-	/* Flex grow */
-	.flex-grow-md--0 { flex-grow: 0; } /* Default */
-	.flex-grow-md--1 { flex-grow: 1; }
-
-
-	/* Flex shrink */
-	.flex-shrink-md--0 { flex-shrink: 0; }
-	.flex-shrink-md--1 { flex-shrink: 1; } /* Default */
-
-
-	/* Flex basis */
-	.flex-basis-md--a { flex-basis: auto; } /* Default */
-	.flex-basis-md--0 { flex-basis: 0; }
-
-
-	/* Align self */
-	.align-self-md--a  { align-self: auto; } /* Default */
-	.align-self-md--fs { align-self: flex-start; }
-	.align-self-md--c  { align-self: center; }
-	.align-self-md--fe { align-self: flex-end; }
-	.align-self-md--s  { align-self: stretch; }
-	.align-self-md--b  { align-self: baseline }
+  .d-md-none {
+    display: none;
+  }
+  .d-md-block {
+    display: block;
+  }
+  .d-md-inline-block {
+    display: inline-block;
+  }
+  .d-md-flex {
+    display: flex;
+  }
+  .d-md-inline-flex {
+    display: inline-flex;
+  }
+  /* Flex direction */
+  .flex-direction-md--r {
+    flex-direction: row;
+  } /* Default */
+  .flex-direction-md--rr {
+    flex-direction: row-reverse;
+  }
+  .flex-direction-md--c {
+    flex-direction: column;
+  }
+  .flex-direction-md--cr {
+    flex-direction: column-reverse;
+  }
+  /* Flex wrap */
+  .flex-wrap-md--n {
+    flex-wrap: nowrap;
+  } /* Default */
+  .flex-wrap-md--w {
+    flex-wrap: wrap;
+  }
+  .flex-wrap-md--wr {
+    flex-wrap: wrap-reverse;
+  }
+  /* Justify content */
+  .justify-content-md--fe {
+    justify-content: flex-end;
+  }
+  .justify-content-md--fs {
+    justify-content: flex-start;
+  } /* Default */
+  .justify-content-md--c {
+    justify-content: center;
+  }
+  .justify-content-md--sa {
+    justify-content: space-around;
+  }
+  .justify-content-md--sb {
+    justify-content: space-between;
+  }
+  /* Align items */
+  .align-items-md--fs {
+    align-items: flex-start;
+  }
+  .align-items-md--c {
+    align-items: center;
+  }
+  .align-items-md--fe {
+    align-items: flex-end;
+  }
+  .align-items-md--s {
+    align-items: stretch;
+  } /* Default */
+  .align-items-md--b {
+    align-items: baseline;
+  }
+  /* Flex grow */
+  .flex-grow-md--0 {
+    flex-grow: 0;
+  } /* Default */
+  .flex-grow-md--1 {
+    flex-grow: 1;
+  }
+  /* Flex shrink */
+  .flex-shrink-md--0 {
+    flex-shrink: 0;
+  }
+  .flex-shrink-md--1 {
+    flex-shrink: 1;
+  } /* Default */
+  /* Flex basis */
+  .flex-basis-md--a {
+    flex-basis: auto;
+  } /* Default */
+  .flex-basis-md--0 {
+    flex-basis: 0;
+  }
+  /* Align self */
+  .align-self-md--a {
+    align-self: auto;
+  } /* Default */
+  .align-self-md--fs {
+    align-self: flex-start;
+  }
+  .align-self-md--c {
+    align-self: center;
+  }
+  .align-self-md--fe {
+    align-self: flex-end;
+  }
+  .align-self-md--s {
+    align-self: stretch;
+  }
+  .align-self-md--b {
+    align-self: baseline
+  }
 }
-
 @media(min-width: 992px) {
-	.d-lg-none  { display: none; }
-	.d-lg-block  { display: block; }
-	.d-lg-inline-block  { display: inline-block; }
-	.d-lg-flex  { display: flex; }
-	.d-lg-inline-flex { display: inline-flex; }
-
-	/* Flex direction */
-	.flex-direction-lg--r  { flex-direction: row; } /* Default */
-	.flex-direction-lg--rr { flex-direction: row-reverse; }
-	.flex-direction-lg--c  { flex-direction: column; }
-	.flex-direction-lg--cr { flex-direction: column-reverse; }
-
-
-	/* Flex wrap */
-	.flex-wrap-lg--n  { flex-wrap: nowrap; } /* Default */
-	.flex-wrap-lg--w  { flex-wrap: wrap; }
-	.flex-wrap-lg--wr { flex-wrap: wrap-reverse; }
-
-
-	/* Justify content */
-	.justify-content-lg--fe { justify-content: flex-end; }
-	.justify-content-lg--fs { justify-content: flex-start; } /* Default */
-	.justify-content-lg--c  { justify-content: center; }
-	.justify-content-lg--sa { justify-content: space-around; }
-	.justify-content-lg--sb { justify-content: space-between; }
-
-
-	/* Align items */
-	.align-items-lg--fs { align-items: flex-start; }
-	.align-items-lg--c  { align-items: center; }
-	.align-items-lg--fe { align-items: flex-end; }
-	.align-items-lg--s  { align-items: stretch; } /* Default */
-	.align-items-lg--b  { align-items: baseline; }
-
-
-	/* Flex grow */
-	.flex-grow-lg--0 { flex-grow: 0; } /* Default */
-	.flex-grow-lg--1 { flex-grow: 1; }
-
-
-	/* Flex shrink */
-	.flex-shrink-lg--0 { flex-shrink: 0; }
-	.flex-shrink-lg--1 { flex-shrink: 1; } /* Default */
-
-
-	/* Flex basis */
-	.flex-basis-lg--a { flex-basis: auto; } /* Default */
-	.flex-basis-lg--0 { flex-basis: 0; }
-
-
-	/* Align self */
-	.align-self-lg--a  { align-self: auto; } /* Default */
-	.align-self-lg--fs { align-self: flex-start; }
-	.align-self-lg--c  { align-self: center; }
-	.align-self-lg--fe { align-self: flex-end; }
-	.align-self-lg--s  { align-self: stretch; }
-	.align-self-lg--b  { align-self: baseline }
+  .d-lg-none {
+    display: none;
+  }
+  .d-lg-block {
+    display: block;
+  }
+  .d-lg-inline-block {
+    display: inline-block;
+  }
+  .d-lg-flex {
+    display: flex;
+  }
+  .d-lg-inline-flex {
+    display: inline-flex;
+  }
+  /* Flex direction */
+  .flex-direction-lg--r {
+    flex-direction: row;
+  } /* Default */
+  .flex-direction-lg--rr {
+    flex-direction: row-reverse;
+  }
+  .flex-direction-lg--c {
+    flex-direction: column;
+  }
+  .flex-direction-lg--cr {
+    flex-direction: column-reverse;
+  }
+  /* Flex wrap */
+  .flex-wrap-lg--n {
+    flex-wrap: nowrap;
+  } /* Default */
+  .flex-wrap-lg--w {
+    flex-wrap: wrap;
+  }
+  .flex-wrap-lg--wr {
+    flex-wrap: wrap-reverse;
+  }
+  /* Justify content */
+  .justify-content-lg--fe {
+    justify-content: flex-end;
+  }
+  .justify-content-lg--fs {
+    justify-content: flex-start;
+  } /* Default */
+  .justify-content-lg--c {
+    justify-content: center;
+  }
+  .justify-content-lg--sa {
+    justify-content: space-around;
+  }
+  .justify-content-lg--sb {
+    justify-content: space-between;
+  }
+  /* Align items */
+  .align-items-lg--fs {
+    align-items: flex-start;
+  }
+  .align-items-lg--c {
+    align-items: center;
+  }
+  .align-items-lg--fe {
+    align-items: flex-end;
+  }
+  .align-items-lg--s {
+    align-items: stretch;
+  } /* Default */
+  .align-items-lg--b {
+    align-items: baseline;
+  }
+  /* Flex grow */
+  .flex-grow-lg--0 {
+    flex-grow: 0;
+  } /* Default */
+  .flex-grow-lg--1 {
+    flex-grow: 1;
+  }
+  /* Flex shrink */
+  .flex-shrink-lg--0 {
+    flex-shrink: 0;
+  }
+  .flex-shrink-lg--1 {
+    flex-shrink: 1;
+  } /* Default */
+  /* Flex basis */
+  .flex-basis-lg--a {
+    flex-basis: auto;
+  } /* Default */
+  .flex-basis-lg--0 {
+    flex-basis: 0;
+  }
+  /* Align self */
+  .align-self-lg--a {
+    align-self: auto;
+  } /* Default */
+  .align-self-lg--fs {
+    align-self: flex-start;
+  }
+  .align-self-lg--c {
+    align-self: center;
+  }
+  .align-self-lg--fe {
+    align-self: flex-end;
+  }
+  .align-self-lg--s {
+    align-self: stretch;
+  }
+  .align-self-lg--b {
+    align-self: baseline
+  }
 }
-
 /*bs4-spacing.css */
 .m-0 {
-	margin: 0 !important; }
-
-.mt-0,
-.my-0 {
-	margin-top: 0 !important; }
-
-.mr-0,
-.mx-0 {
-	margin-right: 0 !important; }
-
-.mb-0,
-.my-0 {
-	margin-bottom: 0 !important; }
-
-.ml-0,
-.mx-0 {
-	margin-left: 0 !important; }
-
+  margin: 0 !important;
+}
+.mt-0, .my-0 {
+  margin-top: 0 !important;
+}
+.mr-0, .mx-0 {
+  margin-right: 0 !important;
+}
+.mb-0, .my-0 {
+  margin-bottom: 0 !important;
+}
+.ml-0, .mx-0 {
+  margin-left: 0 !important;
+}
 .m-1 {
-	margin: 0.25rem !important; }
-
-.mt-1,
-.my-1 {
-	margin-top: 0.25rem !important; }
-
-.mr-1,
-.mx-1 {
-	margin-right: 0.25rem !important; }
-
-.mb-1,
-.my-1 {
-	margin-bottom: 0.25rem !important; }
-
-.ml-1,
-.mx-1 {
-	margin-left: 0.25rem !important; }
-
+  margin: 0.25rem !important;
+}
+.mt-1, .my-1 {
+  margin-top: 0.25rem !important;
+}
+.mr-1, .mx-1 {
+  margin-right: 0.25rem !important;
+}
+.mb-1, .my-1 {
+  margin-bottom: 0.25rem !important;
+}
+.ml-1, .mx-1 {
+  margin-left: 0.25rem !important;
+}
 .m-2 {
-	margin: 0.5rem !important; }
-
-.mt-2,
-.my-2 {
-	margin-top: 0.5rem !important; }
-
-.mr-2,
-.mx-2 {
-	margin-right: 0.5rem !important; }
-
-.mb-2,
-.my-2 {
-	margin-bottom: 0.5rem !important; }
-
-.ml-2,
-.mx-2 {
-	margin-left: 0.5rem !important; }
-
+  margin: 0.5rem !important;
+}
+.mt-2, .my-2 {
+  margin-top: 0.5rem !important;
+}
+.mr-2, .mx-2 {
+  margin-right: 0.5rem !important;
+}
+.mb-2, .my-2 {
+  margin-bottom: 0.5rem !important;
+}
+.ml-2, .mx-2 {
+  margin-left: 0.5rem !important;
+}
 .m-3 {
-	margin: 1rem !important; }
-
-.mt-3,
-.my-3 {
-	margin-top: 1rem !important; }
-
-.mr-3,
-.mx-3 {
-	margin-right: 1rem !important; }
-
-.mb-3,
-.my-3 {
-	margin-bottom: 1rem !important; }
-
-.ml-3,
-.mx-3 {
-	margin-left: 1rem !important; }
-
+  margin: 1rem !important;
+}
+.mt-3, .my-3 {
+  margin-top: 1rem !important;
+}
+.mr-3, .mx-3 {
+  margin-right: 1rem !important;
+}
+.mb-3, .my-3 {
+  margin-bottom: 1rem !important;
+}
+.ml-3, .mx-3 {
+  margin-left: 1rem !important;
+}
 .m-4 {
-	margin: 1.5rem !important; }
-
-.mt-4,
-.my-4 {
-	margin-top: 1.5rem !important; }
-
-.mr-4,
-.mx-4 {
-	margin-right: 1.5rem !important; }
-
-.mb-4,
-.my-4 {
-	margin-bottom: 1.5rem !important; }
-
-.ml-4,
-.mx-4 {
-	margin-left: 1.5rem !important; }
-
+  margin: 1.5rem !important;
+}
+.mt-4, .my-4 {
+  margin-top: 1.5rem !important;
+}
+.mr-4, .mx-4 {
+  margin-right: 1.5rem !important;
+}
+.mb-4, .my-4 {
+  margin-bottom: 1.5rem !important;
+}
+.ml-4, .mx-4 {
+  margin-left: 1.5rem !important;
+}
 .m-5 {
-	margin: 3rem !important; }
-
-.mt-5,
-.my-5 {
-	margin-top: 3rem !important; }
-
-.mr-5,
-.mx-5 {
-	margin-right: 3rem !important; }
-
-.mb-5,
-.my-5 {
-	margin-bottom: 3rem !important; }
-
-.ml-5,
-.mx-5 {
-	margin-left: 3rem !important; }
-
+  margin: 3rem !important;
+}
+.mt-5, .my-5 {
+  margin-top: 3rem !important;
+}
+.mr-5, .mx-5 {
+  margin-right: 3rem !important;
+}
+.mb-5, .my-5 {
+  margin-bottom: 3rem !important;
+}
+.ml-5, .mx-5 {
+  margin-left: 3rem !important;
+}
 .p-0 {
-	padding: 0 !important; }
-
-.pt-0,
-.py-0 {
-	padding-top: 0 !important; }
-
-.pr-0,
-.px-0 {
-	padding-right: 0 !important; }
-
-.pb-0,
-.py-0 {
-	padding-bottom: 0 !important; }
-
-.pl-0,
-.px-0 {
-	padding-left: 0 !important; }
-
+  padding: 0 !important;
+}
+.pt-0, .py-0 {
+  padding-top: 0 !important;
+}
+.pr-0, .px-0 {
+  padding-right: 0 !important;
+}
+.pb-0, .py-0 {
+  padding-bottom: 0 !important;
+}
+.pl-0, .px-0 {
+  padding-left: 0 !important;
+}
 .p-1 {
-	padding: 0.25rem !important; }
-
-.pt-1,
-.py-1 {
-	padding-top: 0.25rem !important; }
-
-.pr-1,
-.px-1 {
-	padding-right: 0.25rem !important; }
-
-.pb-1,
-.py-1 {
-	padding-bottom: 0.25rem !important; }
-
-.pl-1,
-.px-1 {
-	padding-left: 0.25rem !important; }
-
+  padding: 0.25rem !important;
+}
+.pt-1, .py-1 {
+  padding-top: 0.25rem !important;
+}
+.pr-1, .px-1 {
+  padding-right: 0.25rem !important;
+}
+.pb-1, .py-1 {
+  padding-bottom: 0.25rem !important;
+}
+.pl-1, .px-1 {
+  padding-left: 0.25rem !important;
+}
 .p-2 {
-	padding: 0.5rem !important; }
-
-.pt-2,
-.py-2 {
-	padding-top: 0.5rem !important; }
-
-.pr-2,
-.px-2 {
-	padding-right: 0.5rem !important; }
-
-.pb-2,
-.py-2 {
-	padding-bottom: 0.5rem !important; }
-
-.pl-2,
-.px-2 {
-	padding-left: 0.5rem !important; }
-
+  padding: 0.5rem !important;
+}
+.pt-2, .py-2 {
+  padding-top: 0.5rem !important;
+}
+.pr-2, .px-2 {
+  padding-right: 0.5rem !important;
+}
+.pb-2, .py-2 {
+  padding-bottom: 0.5rem !important;
+}
+.pl-2, .px-2 {
+  padding-left: 0.5rem !important;
+}
 .p-3 {
-	padding: 1rem !important; }
-
-.pt-3,
-.py-3 {
-	padding-top: 1rem !important; }
-
-.pr-3,
-.px-3 {
-	padding-right: 1rem !important; }
-
-.pb-3,
-.py-3 {
-	padding-bottom: 1rem !important; }
-
-.pl-3,
-.px-3 {
-	padding-left: 1rem !important; }
-
+  padding: 1rem !important;
+}
+.pt-3, .py-3 {
+  padding-top: 1rem !important;
+}
+.pr-3, .px-3 {
+  padding-right: 1rem !important;
+}
+.pb-3, .py-3 {
+  padding-bottom: 1rem !important;
+}
+.pl-3, .px-3 {
+  padding-left: 1rem !important;
+}
 .p-4 {
-	padding: 1.5rem !important; }
-
-.pt-4,
-.py-4 {
-	padding-top: 1.5rem !important; }
-
-.pr-4,
-.px-4 {
-	padding-right: 1.5rem !important; }
-
-.pb-4,
-.py-4 {
-	padding-bottom: 1.5rem !important; }
-
-.pl-4,
-.px-4 {
-	padding-left: 1.5rem !important; }
-
+  padding: 1.5rem !important;
+}
+.pt-4, .py-4 {
+  padding-top: 1.5rem !important;
+}
+.pr-4, .px-4 {
+  padding-right: 1.5rem !important;
+}
+.pb-4, .py-4 {
+  padding-bottom: 1.5rem !important;
+}
+.pl-4, .px-4 {
+  padding-left: 1.5rem !important;
+}
 .p-5 {
-	padding: 3rem !important; }
-
-.pt-5,
-.py-5 {
-	padding-top: 3rem !important; }
-
-.pr-5,
-.px-5 {
-	padding-right: 3rem !important; }
-
-.pb-5,
-.py-5 {
-	padding-bottom: 3rem !important; }
-
-.pl-5,
-.px-5 {
-	padding-left: 3rem !important; }
-
+  padding: 3rem !important;
+}
+.pt-5, .py-5 {
+  padding-top: 3rem !important;
+}
+.pr-5, .px-5 {
+  padding-right: 3rem !important;
+}
+.pb-5, .py-5 {
+  padding-bottom: 3rem !important;
+}
+.pl-5, .px-5 {
+  padding-left: 3rem !important;
+}
 .m-n1 {
-	margin: -0.25rem !important; }
-
-.mt-n1,
-.my-n1 {
-	margin-top: -0.25rem !important; }
-
-.mr-n1,
-.mx-n1 {
-	margin-right: -0.25rem !important; }
-
-.mb-n1,
-.my-n1 {
-	margin-bottom: -0.25rem !important; }
-
-.ml-n1,
-.mx-n1 {
-	margin-left: -0.25rem !important; }
-
+  margin: -0.25rem !important;
+}
+.mt-n1, .my-n1 {
+  margin-top: -0.25rem !important;
+}
+.mr-n1, .mx-n1 {
+  margin-right: -0.25rem !important;
+}
+.mb-n1, .my-n1 {
+  margin-bottom: -0.25rem !important;
+}
+.ml-n1, .mx-n1 {
+  margin-left: -0.25rem !important;
+}
 .m-n2 {
-	margin: -0.5rem !important; }
-
-.mt-n2,
-.my-n2 {
-	margin-top: -0.5rem !important; }
-
-.mr-n2,
-.mx-n2 {
-	margin-right: -0.5rem !important; }
-
-.mb-n2,
-.my-n2 {
-	margin-bottom: -0.5rem !important; }
-
-.ml-n2,
-.mx-n2 {
-	margin-left: -0.5rem !important; }
-
+  margin: -0.5rem !important;
+}
+.mt-n2, .my-n2 {
+  margin-top: -0.5rem !important;
+}
+.mr-n2, .mx-n2 {
+  margin-right: -0.5rem !important;
+}
+.mb-n2, .my-n2 {
+  margin-bottom: -0.5rem !important;
+}
+.ml-n2, .mx-n2 {
+  margin-left: -0.5rem !important;
+}
 .m-n3 {
-	margin: -1rem !important; }
-
-.mt-n3,
-.my-n3 {
-	margin-top: -1rem !important; }
-
-.mr-n3,
-.mx-n3 {
-	margin-right: -1rem !important; }
-
-.mb-n3,
-.my-n3 {
-	margin-bottom: -1rem !important; }
-
-.ml-n3,
-.mx-n3 {
-	margin-left: -1rem !important; }
-
+  margin: -1rem !important;
+}
+.mt-n3, .my-n3 {
+  margin-top: -1rem !important;
+}
+.mr-n3, .mx-n3 {
+  margin-right: -1rem !important;
+}
+.mb-n3, .my-n3 {
+  margin-bottom: -1rem !important;
+}
+.ml-n3, .mx-n3 {
+  margin-left: -1rem !important;
+}
 .m-n4 {
-	margin: -1.5rem !important; }
-
-.mt-n4,
-.my-n4 {
-	margin-top: -1.5rem !important; }
-
-.mr-n4,
-.mx-n4 {
-	margin-right: -1.5rem !important; }
-
-.mb-n4,
-.my-n4 {
-	margin-bottom: -1.5rem !important; }
-
-.ml-n4,
-.mx-n4 {
-	margin-left: -1.5rem !important; }
-
+  margin: -1.5rem !important;
+}
+.mt-n4, .my-n4 {
+  margin-top: -1.5rem !important;
+}
+.mr-n4, .mx-n4 {
+  margin-right: -1.5rem !important;
+}
+.mb-n4, .my-n4 {
+  margin-bottom: -1.5rem !important;
+}
+.ml-n4, .mx-n4 {
+  margin-left: -1.5rem !important;
+}
 .m-n5 {
-	margin: -3rem !important; }
-
-.mt-n5,
-.my-n5 {
-	margin-top: -3rem !important; }
-
-.mr-n5,
-.mx-n5 {
-	margin-right: -3rem !important; }
-
-.mb-n5,
-.my-n5 {
-	margin-bottom: -3rem !important; }
-
-.ml-n5,
-.mx-n5 {
-	margin-left: -3rem !important; }
-
+  margin: -3rem !important;
+}
+.mt-n5, .my-n5 {
+  margin-top: -3rem !important;
+}
+.mr-n5, .mx-n5 {
+  margin-right: -3rem !important;
+}
+.mb-n5, .my-n5 {
+  margin-bottom: -3rem !important;
+}
+.ml-n5, .mx-n5 {
+  margin-left: -3rem !important;
+}
 .m-auto {
-	margin: auto !important; }
-
-.mt-auto,
-.my-auto {
-	margin-top: auto !important; }
-
-.mr-auto,
-.mx-auto {
-	margin-right: auto !important; }
-
-.mb-auto,
-.my-auto {
-	margin-bottom: auto !important; }
-
-.ml-auto,
-.mx-auto {
-	margin-left: auto !important; }
-
+  margin: auto !important;
+}
+.mt-auto, .my-auto {
+  margin-top: auto !important;
+}
+.mr-auto, .mx-auto {
+  margin-right: auto !important;
+}
+.mb-auto, .my-auto {
+  margin-bottom: auto !important;
+}
+.ml-auto, .mx-auto {
+  margin-left: auto !important;
+}
 @media (min-width: 576px) {
-	.m-sm-0 {
-		margin: 0 !important; }
-	.mt-sm-0,
-	.my-sm-0 {
-		margin-top: 0 !important; }
-	.mr-sm-0,
-	.mx-sm-0 {
-		margin-right: 0 !important; }
-	.mb-sm-0,
-	.my-sm-0 {
-		margin-bottom: 0 !important; }
-	.ml-sm-0,
-	.mx-sm-0 {
-		margin-left: 0 !important; }
-	.m-sm-1 {
-		margin: 0.25rem !important; }
-	.mt-sm-1,
-	.my-sm-1 {
-		margin-top: 0.25rem !important; }
-	.mr-sm-1,
-	.mx-sm-1 {
-		margin-right: 0.25rem !important; }
-	.mb-sm-1,
-	.my-sm-1 {
-		margin-bottom: 0.25rem !important; }
-	.ml-sm-1,
-	.mx-sm-1 {
-		margin-left: 0.25rem !important; }
-	.m-sm-2 {
-		margin: 0.5rem !important; }
-	.mt-sm-2,
-	.my-sm-2 {
-		margin-top: 0.5rem !important; }
-	.mr-sm-2,
-	.mx-sm-2 {
-		margin-right: 0.5rem !important; }
-	.mb-sm-2,
-	.my-sm-2 {
-		margin-bottom: 0.5rem !important; }
-	.ml-sm-2,
-	.mx-sm-2 {
-		margin-left: 0.5rem !important; }
-	.m-sm-3 {
-		margin: 1rem !important; }
-	.mt-sm-3,
-	.my-sm-3 {
-		margin-top: 1rem !important; }
-	.mr-sm-3,
-	.mx-sm-3 {
-		margin-right: 1rem !important; }
-	.mb-sm-3,
-	.my-sm-3 {
-		margin-bottom: 1rem !important; }
-	.ml-sm-3,
-	.mx-sm-3 {
-		margin-left: 1rem !important; }
-	.m-sm-4 {
-		margin: 1.5rem !important; }
-	.mt-sm-4,
-	.my-sm-4 {
-		margin-top: 1.5rem !important; }
-	.mr-sm-4,
-	.mx-sm-4 {
-		margin-right: 1.5rem !important; }
-	.mb-sm-4,
-	.my-sm-4 {
-		margin-bottom: 1.5rem !important; }
-	.ml-sm-4,
-	.mx-sm-4 {
-		margin-left: 1.5rem !important; }
-	.m-sm-5 {
-		margin: 3rem !important; }
-	.mt-sm-5,
-	.my-sm-5 {
-		margin-top: 3rem !important; }
-	.mr-sm-5,
-	.mx-sm-5 {
-		margin-right: 3rem !important; }
-	.mb-sm-5,
-	.my-sm-5 {
-		margin-bottom: 3rem !important; }
-	.ml-sm-5,
-	.mx-sm-5 {
-		margin-left: 3rem !important; }
-	.p-sm-0 {
-		padding: 0 !important; }
-	.pt-sm-0,
-	.py-sm-0 {
-		padding-top: 0 !important; }
-	.pr-sm-0,
-	.px-sm-0 {
-		padding-right: 0 !important; }
-	.pb-sm-0,
-	.py-sm-0 {
-		padding-bottom: 0 !important; }
-	.pl-sm-0,
-	.px-sm-0 {
-		padding-left: 0 !important; }
-	.p-sm-1 {
-		padding: 0.25rem !important; }
-	.pt-sm-1,
-	.py-sm-1 {
-		padding-top: 0.25rem !important; }
-	.pr-sm-1,
-	.px-sm-1 {
-		padding-right: 0.25rem !important; }
-	.pb-sm-1,
-	.py-sm-1 {
-		padding-bottom: 0.25rem !important; }
-	.pl-sm-1,
-	.px-sm-1 {
-		padding-left: 0.25rem !important; }
-	.p-sm-2 {
-		padding: 0.5rem !important; }
-	.pt-sm-2,
-	.py-sm-2 {
-		padding-top: 0.5rem !important; }
-	.pr-sm-2,
-	.px-sm-2 {
-		padding-right: 0.5rem !important; }
-	.pb-sm-2,
-	.py-sm-2 {
-		padding-bottom: 0.5rem !important; }
-	.pl-sm-2,
-	.px-sm-2 {
-		padding-left: 0.5rem !important; }
-	.p-sm-3 {
-		padding: 1rem !important; }
-	.pt-sm-3,
-	.py-sm-3 {
-		padding-top: 1rem !important; }
-	.pr-sm-3,
-	.px-sm-3 {
-		padding-right: 1rem !important; }
-	.pb-sm-3,
-	.py-sm-3 {
-		padding-bottom: 1rem !important; }
-	.pl-sm-3,
-	.px-sm-3 {
-		padding-left: 1rem !important; }
-	.p-sm-4 {
-		padding: 1.5rem !important; }
-	.pt-sm-4,
-	.py-sm-4 {
-		padding-top: 1.5rem !important; }
-	.pr-sm-4,
-	.px-sm-4 {
-		padding-right: 1.5rem !important; }
-	.pb-sm-4,
-	.py-sm-4 {
-		padding-bottom: 1.5rem !important; }
-	.pl-sm-4,
-	.px-sm-4 {
-		padding-left: 1.5rem !important; }
-	.p-sm-5 {
-		padding: 3rem !important; }
-	.pt-sm-5,
-	.py-sm-5 {
-		padding-top: 3rem !important; }
-	.pr-sm-5,
-	.px-sm-5 {
-		padding-right: 3rem !important; }
-	.pb-sm-5,
-	.py-sm-5 {
-		padding-bottom: 3rem !important; }
-	.pl-sm-5,
-	.px-sm-5 {
-		padding-left: 3rem !important; }
-	.m-sm-n1 {
-		margin: -0.25rem !important; }
-	.mt-sm-n1,
-	.my-sm-n1 {
-		margin-top: -0.25rem !important; }
-	.mr-sm-n1,
-	.mx-sm-n1 {
-		margin-right: -0.25rem !important; }
-	.mb-sm-n1,
-	.my-sm-n1 {
-		margin-bottom: -0.25rem !important; }
-	.ml-sm-n1,
-	.mx-sm-n1 {
-		margin-left: -0.25rem !important; }
-	.m-sm-n2 {
-		margin: -0.5rem !important; }
-	.mt-sm-n2,
-	.my-sm-n2 {
-		margin-top: -0.5rem !important; }
-	.mr-sm-n2,
-	.mx-sm-n2 {
-		margin-right: -0.5rem !important; }
-	.mb-sm-n2,
-	.my-sm-n2 {
-		margin-bottom: -0.5rem !important; }
-	.ml-sm-n2,
-	.mx-sm-n2 {
-		margin-left: -0.5rem !important; }
-	.m-sm-n3 {
-		margin: -1rem !important; }
-	.mt-sm-n3,
-	.my-sm-n3 {
-		margin-top: -1rem !important; }
-	.mr-sm-n3,
-	.mx-sm-n3 {
-		margin-right: -1rem !important; }
-	.mb-sm-n3,
-	.my-sm-n3 {
-		margin-bottom: -1rem !important; }
-	.ml-sm-n3,
-	.mx-sm-n3 {
-		margin-left: -1rem !important; }
-	.m-sm-n4 {
-		margin: -1.5rem !important; }
-	.mt-sm-n4,
-	.my-sm-n4 {
-		margin-top: -1.5rem !important; }
-	.mr-sm-n4,
-	.mx-sm-n4 {
-		margin-right: -1.5rem !important; }
-	.mb-sm-n4,
-	.my-sm-n4 {
-		margin-bottom: -1.5rem !important; }
-	.ml-sm-n4,
-	.mx-sm-n4 {
-		margin-left: -1.5rem !important; }
-	.m-sm-n5 {
-		margin: -3rem !important; }
-	.mt-sm-n5,
-	.my-sm-n5 {
-		margin-top: -3rem !important; }
-	.mr-sm-n5,
-	.mx-sm-n5 {
-		margin-right: -3rem !important; }
-	.mb-sm-n5,
-	.my-sm-n5 {
-		margin-bottom: -3rem !important; }
-	.ml-sm-n5,
-	.mx-sm-n5 {
-		margin-left: -3rem !important; }
-	.m-sm-auto {
-		margin: auto !important; }
-	.mt-sm-auto,
-	.my-sm-auto {
-		margin-top: auto !important; }
-	.mr-sm-auto,
-	.mx-sm-auto {
-		margin-right: auto !important; }
-	.mb-sm-auto,
-	.my-sm-auto {
-		margin-bottom: auto !important; }
-	.ml-sm-auto,
-	.mx-sm-auto {
-		margin-left: auto !important; } }
-
+  .m-sm-0 {
+    margin: 0 !important;
+  }
+  .mt-sm-0, .my-sm-0 {
+    margin-top: 0 !important;
+  }
+  .mr-sm-0, .mx-sm-0 {
+    margin-right: 0 !important;
+  }
+  .mb-sm-0, .my-sm-0 {
+    margin-bottom: 0 !important;
+  }
+  .ml-sm-0, .mx-sm-0 {
+    margin-left: 0 !important;
+  }
+  .m-sm-1 {
+    margin: 0.25rem !important;
+  }
+  .mt-sm-1, .my-sm-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mr-sm-1, .mx-sm-1 {
+    margin-right: 0.25rem !important;
+  }
+  .mb-sm-1, .my-sm-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .ml-sm-1, .mx-sm-1 {
+    margin-left: 0.25rem !important;
+  }
+  .m-sm-2 {
+    margin: 0.5rem !important;
+  }
+  .mt-sm-2, .my-sm-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mr-sm-2, .mx-sm-2 {
+    margin-right: 0.5rem !important;
+  }
+  .mb-sm-2, .my-sm-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .ml-sm-2, .mx-sm-2 {
+    margin-left: 0.5rem !important;
+  }
+  .m-sm-3 {
+    margin: 1rem !important;
+  }
+  .mt-sm-3, .my-sm-3 {
+    margin-top: 1rem !important;
+  }
+  .mr-sm-3, .mx-sm-3 {
+    margin-right: 1rem !important;
+  }
+  .mb-sm-3, .my-sm-3 {
+    margin-bottom: 1rem !important;
+  }
+  .ml-sm-3, .mx-sm-3 {
+    margin-left: 1rem !important;
+  }
+  .m-sm-4 {
+    margin: 1.5rem !important;
+  }
+  .mt-sm-4, .my-sm-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mr-sm-4, .mx-sm-4 {
+    margin-right: 1.5rem !important;
+  }
+  .mb-sm-4, .my-sm-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .ml-sm-4, .mx-sm-4 {
+    margin-left: 1.5rem !important;
+  }
+  .m-sm-5 {
+    margin: 3rem !important;
+  }
+  .mt-sm-5, .my-sm-5 {
+    margin-top: 3rem !important;
+  }
+  .mr-sm-5, .mx-sm-5 {
+    margin-right: 3rem !important;
+  }
+  .mb-sm-5, .my-sm-5 {
+    margin-bottom: 3rem !important;
+  }
+  .ml-sm-5, .mx-sm-5 {
+    margin-left: 3rem !important;
+  }
+  .p-sm-0 {
+    padding: 0 !important;
+  }
+  .pt-sm-0, .py-sm-0 {
+    padding-top: 0 !important;
+  }
+  .pr-sm-0, .px-sm-0 {
+    padding-right: 0 !important;
+  }
+  .pb-sm-0, .py-sm-0 {
+    padding-bottom: 0 !important;
+  }
+  .pl-sm-0, .px-sm-0 {
+    padding-left: 0 !important;
+  }
+  .p-sm-1 {
+    padding: 0.25rem !important;
+  }
+  .pt-sm-1, .py-sm-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pr-sm-1, .px-sm-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pb-sm-1, .py-sm-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pl-sm-1, .px-sm-1 {
+    padding-left: 0.25rem !important;
+  }
+  .p-sm-2 {
+    padding: 0.5rem !important;
+  }
+  .pt-sm-2, .py-sm-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pr-sm-2, .px-sm-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pb-sm-2, .py-sm-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pl-sm-2, .px-sm-2 {
+    padding-left: 0.5rem !important;
+  }
+  .p-sm-3 {
+    padding: 1rem !important;
+  }
+  .pt-sm-3, .py-sm-3 {
+    padding-top: 1rem !important;
+  }
+  .pr-sm-3, .px-sm-3 {
+    padding-right: 1rem !important;
+  }
+  .pb-sm-3, .py-sm-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pl-sm-3, .px-sm-3 {
+    padding-left: 1rem !important;
+  }
+  .p-sm-4 {
+    padding: 1.5rem !important;
+  }
+  .pt-sm-4, .py-sm-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pr-sm-4, .px-sm-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pb-sm-4, .py-sm-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pl-sm-4, .px-sm-4 {
+    padding-left: 1.5rem !important;
+  }
+  .p-sm-5 {
+    padding: 3rem !important;
+  }
+  .pt-sm-5, .py-sm-5 {
+    padding-top: 3rem !important;
+  }
+  .pr-sm-5, .px-sm-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-sm-5, .py-sm-5 {
+    padding-bottom: 3rem !important;
+  }
+  .pl-sm-5, .px-sm-5 {
+    padding-left: 3rem !important;
+  }
+  .m-sm-n1 {
+    margin: -0.25rem !important;
+  }
+  .mt-sm-n1, .my-sm-n1 {
+    margin-top: -0.25rem !important;
+  }
+  .mr-sm-n1, .mx-sm-n1 {
+    margin-right: -0.25rem !important;
+  }
+  .mb-sm-n1, .my-sm-n1 {
+    margin-bottom: -0.25rem !important;
+  }
+  .ml-sm-n1, .mx-sm-n1 {
+    margin-left: -0.25rem !important;
+  }
+  .m-sm-n2 {
+    margin: -0.5rem !important;
+  }
+  .mt-sm-n2, .my-sm-n2 {
+    margin-top: -0.5rem !important;
+  }
+  .mr-sm-n2, .mx-sm-n2 {
+    margin-right: -0.5rem !important;
+  }
+  .mb-sm-n2, .my-sm-n2 {
+    margin-bottom: -0.5rem !important;
+  }
+  .ml-sm-n2, .mx-sm-n2 {
+    margin-left: -0.5rem !important;
+  }
+  .m-sm-n3 {
+    margin: -1rem !important;
+  }
+  .mt-sm-n3, .my-sm-n3 {
+    margin-top: -1rem !important;
+  }
+  .mr-sm-n3, .mx-sm-n3 {
+    margin-right: -1rem !important;
+  }
+  .mb-sm-n3, .my-sm-n3 {
+    margin-bottom: -1rem !important;
+  }
+  .ml-sm-n3, .mx-sm-n3 {
+    margin-left: -1rem !important;
+  }
+  .m-sm-n4 {
+    margin: -1.5rem !important;
+  }
+  .mt-sm-n4, .my-sm-n4 {
+    margin-top: -1.5rem !important;
+  }
+  .mr-sm-n4, .mx-sm-n4 {
+    margin-right: -1.5rem !important;
+  }
+  .mb-sm-n4, .my-sm-n4 {
+    margin-bottom: -1.5rem !important;
+  }
+  .ml-sm-n4, .mx-sm-n4 {
+    margin-left: -1.5rem !important;
+  }
+  .m-sm-n5 {
+    margin: -3rem !important;
+  }
+  .mt-sm-n5, .my-sm-n5 {
+    margin-top: -3rem !important;
+  }
+  .mr-sm-n5, .mx-sm-n5 {
+    margin-right: -3rem !important;
+  }
+  .mb-sm-n5, .my-sm-n5 {
+    margin-bottom: -3rem !important;
+  }
+  .ml-sm-n5, .mx-sm-n5 {
+    margin-left: -3rem !important;
+  }
+  .m-sm-auto {
+    margin: auto !important;
+  }
+  .mt-sm-auto, .my-sm-auto {
+    margin-top: auto !important;
+  }
+  .mr-sm-auto, .mx-sm-auto {
+    margin-right: auto !important;
+  }
+  .mb-sm-auto, .my-sm-auto {
+    margin-bottom: auto !important;
+  }
+  .ml-sm-auto, .mx-sm-auto {
+    margin-left: auto !important;
+  }
+}
 @media (min-width: 768px) {
-	.m-md-0 {
-		margin: 0 !important; }
-	.mt-md-0,
-	.my-md-0 {
-		margin-top: 0 !important; }
-	.mr-md-0,
-	.mx-md-0 {
-		margin-right: 0 !important; }
-	.mb-md-0,
-	.my-md-0 {
-		margin-bottom: 0 !important; }
-	.ml-md-0,
-	.mx-md-0 {
-		margin-left: 0 !important; }
-	.m-md-1 {
-		margin: 0.25rem !important; }
-	.mt-md-1,
-	.my-md-1 {
-		margin-top: 0.25rem !important; }
-	.mr-md-1,
-	.mx-md-1 {
-		margin-right: 0.25rem !important; }
-	.mb-md-1,
-	.my-md-1 {
-		margin-bottom: 0.25rem !important; }
-	.ml-md-1,
-	.mx-md-1 {
-		margin-left: 0.25rem !important; }
-	.m-md-2 {
-		margin: 0.5rem !important; }
-	.mt-md-2,
-	.my-md-2 {
-		margin-top: 0.5rem !important; }
-	.mr-md-2,
-	.mx-md-2 {
-		margin-right: 0.5rem !important; }
-	.mb-md-2,
-	.my-md-2 {
-		margin-bottom: 0.5rem !important; }
-	.ml-md-2,
-	.mx-md-2 {
-		margin-left: 0.5rem !important; }
-	.m-md-3 {
-		margin: 1rem !important; }
-	.mt-md-3,
-	.my-md-3 {
-		margin-top: 1rem !important; }
-	.mr-md-3,
-	.mx-md-3 {
-		margin-right: 1rem !important; }
-	.mb-md-3,
-	.my-md-3 {
-		margin-bottom: 1rem !important; }
-	.ml-md-3,
-	.mx-md-3 {
-		margin-left: 1rem !important; }
-	.m-md-4 {
-		margin: 1.5rem !important; }
-	.mt-md-4,
-	.my-md-4 {
-		margin-top: 1.5rem !important; }
-	.mr-md-4,
-	.mx-md-4 {
-		margin-right: 1.5rem !important; }
-	.mb-md-4,
-	.my-md-4 {
-		margin-bottom: 1.5rem !important; }
-	.ml-md-4,
-	.mx-md-4 {
-		margin-left: 1.5rem !important; }
-	.m-md-5 {
-		margin: 3rem !important; }
-	.mt-md-5,
-	.my-md-5 {
-		margin-top: 3rem !important; }
-	.mr-md-5,
-	.mx-md-5 {
-		margin-right: 3rem !important; }
-	.mb-md-5,
-	.my-md-5 {
-		margin-bottom: 3rem !important; }
-	.ml-md-5,
-	.mx-md-5 {
-		margin-left: 3rem !important; }
-	.p-md-0 {
-		padding: 0 !important; }
-	.pt-md-0,
-	.py-md-0 {
-		padding-top: 0 !important; }
-	.pr-md-0,
-	.px-md-0 {
-		padding-right: 0 !important; }
-	.pb-md-0,
-	.py-md-0 {
-		padding-bottom: 0 !important; }
-	.pl-md-0,
-	.px-md-0 {
-		padding-left: 0 !important; }
-	.p-md-1 {
-		padding: 0.25rem !important; }
-	.pt-md-1,
-	.py-md-1 {
-		padding-top: 0.25rem !important; }
-	.pr-md-1,
-	.px-md-1 {
-		padding-right: 0.25rem !important; }
-	.pb-md-1,
-	.py-md-1 {
-		padding-bottom: 0.25rem !important; }
-	.pl-md-1,
-	.px-md-1 {
-		padding-left: 0.25rem !important; }
-	.p-md-2 {
-		padding: 0.5rem !important; }
-	.pt-md-2,
-	.py-md-2 {
-		padding-top: 0.5rem !important; }
-	.pr-md-2,
-	.px-md-2 {
-		padding-right: 0.5rem !important; }
-	.pb-md-2,
-	.py-md-2 {
-		padding-bottom: 0.5rem !important; }
-	.pl-md-2,
-	.px-md-2 {
-		padding-left: 0.5rem !important; }
-	.p-md-3 {
-		padding: 1rem !important; }
-	.pt-md-3,
-	.py-md-3 {
-		padding-top: 1rem !important; }
-	.pr-md-3,
-	.px-md-3 {
-		padding-right: 1rem !important; }
-	.pb-md-3,
-	.py-md-3 {
-		padding-bottom: 1rem !important; }
-	.pl-md-3,
-	.px-md-3 {
-		padding-left: 1rem !important; }
-	.p-md-4 {
-		padding: 1.5rem !important; }
-	.pt-md-4,
-	.py-md-4 {
-		padding-top: 1.5rem !important; }
-	.pr-md-4,
-	.px-md-4 {
-		padding-right: 1.5rem !important; }
-	.pb-md-4,
-	.py-md-4 {
-		padding-bottom: 1.5rem !important; }
-	.pl-md-4,
-	.px-md-4 {
-		padding-left: 1.5rem !important; }
-	.p-md-5 {
-		padding: 3rem !important; }
-	.pt-md-5,
-	.py-md-5 {
-		padding-top: 3rem !important; }
-	.pr-md-5,
-	.px-md-5 {
-		padding-right: 3rem !important; }
-	.pb-md-5,
-	.py-md-5 {
-		padding-bottom: 3rem !important; }
-	.pl-md-5,
-	.px-md-5 {
-		padding-left: 3rem !important; }
-	.m-md-n1 {
-		margin: -0.25rem !important; }
-	.mt-md-n1,
-	.my-md-n1 {
-		margin-top: -0.25rem !important; }
-	.mr-md-n1,
-	.mx-md-n1 {
-		margin-right: -0.25rem !important; }
-	.mb-md-n1,
-	.my-md-n1 {
-		margin-bottom: -0.25rem !important; }
-	.ml-md-n1,
-	.mx-md-n1 {
-		margin-left: -0.25rem !important; }
-	.m-md-n2 {
-		margin: -0.5rem !important; }
-	.mt-md-n2,
-	.my-md-n2 {
-		margin-top: -0.5rem !important; }
-	.mr-md-n2,
-	.mx-md-n2 {
-		margin-right: -0.5rem !important; }
-	.mb-md-n2,
-	.my-md-n2 {
-		margin-bottom: -0.5rem !important; }
-	.ml-md-n2,
-	.mx-md-n2 {
-		margin-left: -0.5rem !important; }
-	.m-md-n3 {
-		margin: -1rem !important; }
-	.mt-md-n3,
-	.my-md-n3 {
-		margin-top: -1rem !important; }
-	.mr-md-n3,
-	.mx-md-n3 {
-		margin-right: -1rem !important; }
-	.mb-md-n3,
-	.my-md-n3 {
-		margin-bottom: -1rem !important; }
-	.ml-md-n3,
-	.mx-md-n3 {
-		margin-left: -1rem !important; }
-	.m-md-n4 {
-		margin: -1.5rem !important; }
-	.mt-md-n4,
-	.my-md-n4 {
-		margin-top: -1.5rem !important; }
-	.mr-md-n4,
-	.mx-md-n4 {
-		margin-right: -1.5rem !important; }
-	.mb-md-n4,
-	.my-md-n4 {
-		margin-bottom: -1.5rem !important; }
-	.ml-md-n4,
-	.mx-md-n4 {
-		margin-left: -1.5rem !important; }
-	.m-md-n5 {
-		margin: -3rem !important; }
-	.mt-md-n5,
-	.my-md-n5 {
-		margin-top: -3rem !important; }
-	.mr-md-n5,
-	.mx-md-n5 {
-		margin-right: -3rem !important; }
-	.mb-md-n5,
-	.my-md-n5 {
-		margin-bottom: -3rem !important; }
-	.ml-md-n5,
-	.mx-md-n5 {
-		margin-left: -3rem !important; }
-	.m-md-auto {
-		margin: auto !important; }
-	.mt-md-auto,
-	.my-md-auto {
-		margin-top: auto !important; }
-	.mr-md-auto,
-	.mx-md-auto {
-		margin-right: auto !important; }
-	.mb-md-auto,
-	.my-md-auto {
-		margin-bottom: auto !important; }
-	.ml-md-auto,
-	.mx-md-auto {
-		margin-left: auto !important; } }
-
+  .m-md-0 {
+    margin: 0 !important;
+  }
+  .mt-md-0, .my-md-0 {
+    margin-top: 0 !important;
+  }
+  .mr-md-0, .mx-md-0 {
+    margin-right: 0 !important;
+  }
+  .mb-md-0, .my-md-0 {
+    margin-bottom: 0 !important;
+  }
+  .ml-md-0, .mx-md-0 {
+    margin-left: 0 !important;
+  }
+  .m-md-1 {
+    margin: 0.25rem !important;
+  }
+  .mt-md-1, .my-md-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mr-md-1, .mx-md-1 {
+    margin-right: 0.25rem !important;
+  }
+  .mb-md-1, .my-md-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .ml-md-1, .mx-md-1 {
+    margin-left: 0.25rem !important;
+  }
+  .m-md-2 {
+    margin: 0.5rem !important;
+  }
+  .mt-md-2, .my-md-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mr-md-2, .mx-md-2 {
+    margin-right: 0.5rem !important;
+  }
+  .mb-md-2, .my-md-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .ml-md-2, .mx-md-2 {
+    margin-left: 0.5rem !important;
+  }
+  .m-md-3 {
+    margin: 1rem !important;
+  }
+  .mt-md-3, .my-md-3 {
+    margin-top: 1rem !important;
+  }
+  .mr-md-3, .mx-md-3 {
+    margin-right: 1rem !important;
+  }
+  .mb-md-3, .my-md-3 {
+    margin-bottom: 1rem !important;
+  }
+  .ml-md-3, .mx-md-3 {
+    margin-left: 1rem !important;
+  }
+  .m-md-4 {
+    margin: 1.5rem !important;
+  }
+  .mt-md-4, .my-md-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mr-md-4, .mx-md-4 {
+    margin-right: 1.5rem !important;
+  }
+  .mb-md-4, .my-md-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .ml-md-4, .mx-md-4 {
+    margin-left: 1.5rem !important;
+  }
+  .m-md-5 {
+    margin: 3rem !important;
+  }
+  .mt-md-5, .my-md-5 {
+    margin-top: 3rem !important;
+  }
+  .mr-md-5, .mx-md-5 {
+    margin-right: 3rem !important;
+  }
+  .mb-md-5, .my-md-5 {
+    margin-bottom: 3rem !important;
+  }
+  .ml-md-5, .mx-md-5 {
+    margin-left: 3rem !important;
+  }
+  .p-md-0 {
+    padding: 0 !important;
+  }
+  .pt-md-0, .py-md-0 {
+    padding-top: 0 !important;
+  }
+  .pr-md-0, .px-md-0 {
+    padding-right: 0 !important;
+  }
+  .pb-md-0, .py-md-0 {
+    padding-bottom: 0 !important;
+  }
+  .pl-md-0, .px-md-0 {
+    padding-left: 0 !important;
+  }
+  .p-md-1 {
+    padding: 0.25rem !important;
+  }
+  .pt-md-1, .py-md-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pr-md-1, .px-md-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pb-md-1, .py-md-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pl-md-1, .px-md-1 {
+    padding-left: 0.25rem !important;
+  }
+  .p-md-2 {
+    padding: 0.5rem !important;
+  }
+  .pt-md-2, .py-md-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pr-md-2, .px-md-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pb-md-2, .py-md-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pl-md-2, .px-md-2 {
+    padding-left: 0.5rem !important;
+  }
+  .p-md-3 {
+    padding: 1rem !important;
+  }
+  .pt-md-3, .py-md-3 {
+    padding-top: 1rem !important;
+  }
+  .pr-md-3, .px-md-3 {
+    padding-right: 1rem !important;
+  }
+  .pb-md-3, .py-md-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pl-md-3, .px-md-3 {
+    padding-left: 1rem !important;
+  }
+  .p-md-4 {
+    padding: 1.5rem !important;
+  }
+  .pt-md-4, .py-md-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pr-md-4, .px-md-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pb-md-4, .py-md-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pl-md-4, .px-md-4 {
+    padding-left: 1.5rem !important;
+  }
+  .p-md-5 {
+    padding: 3rem !important;
+  }
+  .pt-md-5, .py-md-5 {
+    padding-top: 3rem !important;
+  }
+  .pr-md-5, .px-md-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-md-5, .py-md-5 {
+    padding-bottom: 3rem !important;
+  }
+  .pl-md-5, .px-md-5 {
+    padding-left: 3rem !important;
+  }
+  .m-md-n1 {
+    margin: -0.25rem !important;
+  }
+  .mt-md-n1, .my-md-n1 {
+    margin-top: -0.25rem !important;
+  }
+  .mr-md-n1, .mx-md-n1 {
+    margin-right: -0.25rem !important;
+  }
+  .mb-md-n1, .my-md-n1 {
+    margin-bottom: -0.25rem !important;
+  }
+  .ml-md-n1, .mx-md-n1 {
+    margin-left: -0.25rem !important;
+  }
+  .m-md-n2 {
+    margin: -0.5rem !important;
+  }
+  .mt-md-n2, .my-md-n2 {
+    margin-top: -0.5rem !important;
+  }
+  .mr-md-n2, .mx-md-n2 {
+    margin-right: -0.5rem !important;
+  }
+  .mb-md-n2, .my-md-n2 {
+    margin-bottom: -0.5rem !important;
+  }
+  .ml-md-n2, .mx-md-n2 {
+    margin-left: -0.5rem !important;
+  }
+  .m-md-n3 {
+    margin: -1rem !important;
+  }
+  .mt-md-n3, .my-md-n3 {
+    margin-top: -1rem !important;
+  }
+  .mr-md-n3, .mx-md-n3 {
+    margin-right: -1rem !important;
+  }
+  .mb-md-n3, .my-md-n3 {
+    margin-bottom: -1rem !important;
+  }
+  .ml-md-n3, .mx-md-n3 {
+    margin-left: -1rem !important;
+  }
+  .m-md-n4 {
+    margin: -1.5rem !important;
+  }
+  .mt-md-n4, .my-md-n4 {
+    margin-top: -1.5rem !important;
+  }
+  .mr-md-n4, .mx-md-n4 {
+    margin-right: -1.5rem !important;
+  }
+  .mb-md-n4, .my-md-n4 {
+    margin-bottom: -1.5rem !important;
+  }
+  .ml-md-n4, .mx-md-n4 {
+    margin-left: -1.5rem !important;
+  }
+  .m-md-n5 {
+    margin: -3rem !important;
+  }
+  .mt-md-n5, .my-md-n5 {
+    margin-top: -3rem !important;
+  }
+  .mr-md-n5, .mx-md-n5 {
+    margin-right: -3rem !important;
+  }
+  .mb-md-n5, .my-md-n5 {
+    margin-bottom: -3rem !important;
+  }
+  .ml-md-n5, .mx-md-n5 {
+    margin-left: -3rem !important;
+  }
+  .m-md-auto {
+    margin: auto !important;
+  }
+  .mt-md-auto, .my-md-auto {
+    margin-top: auto !important;
+  }
+  .mr-md-auto, .mx-md-auto {
+    margin-right: auto !important;
+  }
+  .mb-md-auto, .my-md-auto {
+    margin-bottom: auto !important;
+  }
+  .ml-md-auto, .mx-md-auto {
+    margin-left: auto !important;
+  }
+}
 @media (min-width: 992px) {
-	.m-lg-0 {
-		margin: 0 !important; }
-	.mt-lg-0,
-	.my-lg-0 {
-		margin-top: 0 !important; }
-	.mr-lg-0,
-	.mx-lg-0 {
-		margin-right: 0 !important; }
-	.mb-lg-0,
-	.my-lg-0 {
-		margin-bottom: 0 !important; }
-	.ml-lg-0,
-	.mx-lg-0 {
-		margin-left: 0 !important; }
-	.m-lg-1 {
-		margin: 0.25rem !important; }
-	.mt-lg-1,
-	.my-lg-1 {
-		margin-top: 0.25rem !important; }
-	.mr-lg-1,
-	.mx-lg-1 {
-		margin-right: 0.25rem !important; }
-	.mb-lg-1,
-	.my-lg-1 {
-		margin-bottom: 0.25rem !important; }
-	.ml-lg-1,
-	.mx-lg-1 {
-		margin-left: 0.25rem !important; }
-	.m-lg-2 {
-		margin: 0.5rem !important; }
-	.mt-lg-2,
-	.my-lg-2 {
-		margin-top: 0.5rem !important; }
-	.mr-lg-2,
-	.mx-lg-2 {
-		margin-right: 0.5rem !important; }
-	.mb-lg-2,
-	.my-lg-2 {
-		margin-bottom: 0.5rem !important; }
-	.ml-lg-2,
-	.mx-lg-2 {
-		margin-left: 0.5rem !important; }
-	.m-lg-3 {
-		margin: 1rem !important; }
-	.mt-lg-3,
-	.my-lg-3 {
-		margin-top: 1rem !important; }
-	.mr-lg-3,
-	.mx-lg-3 {
-		margin-right: 1rem !important; }
-	.mb-lg-3,
-	.my-lg-3 {
-		margin-bottom: 1rem !important; }
-	.ml-lg-3,
-	.mx-lg-3 {
-		margin-left: 1rem !important; }
-	.m-lg-4 {
-		margin: 1.5rem !important; }
-	.mt-lg-4,
-	.my-lg-4 {
-		margin-top: 1.5rem !important; }
-	.mr-lg-4,
-	.mx-lg-4 {
-		margin-right: 1.5rem !important; }
-	.mb-lg-4,
-	.my-lg-4 {
-		margin-bottom: 1.5rem !important; }
-	.ml-lg-4,
-	.mx-lg-4 {
-		margin-left: 1.5rem !important; }
-	.m-lg-5 {
-		margin: 3rem !important; }
-	.mt-lg-5,
-	.my-lg-5 {
-		margin-top: 3rem !important; }
-	.mr-lg-5,
-	.mx-lg-5 {
-		margin-right: 3rem !important; }
-	.mb-lg-5,
-	.my-lg-5 {
-		margin-bottom: 3rem !important; }
-	.ml-lg-5,
-	.mx-lg-5 {
-		margin-left: 3rem !important; }
-	.p-lg-0 {
-		padding: 0 !important; }
-	.pt-lg-0,
-	.py-lg-0 {
-		padding-top: 0 !important; }
-	.pr-lg-0,
-	.px-lg-0 {
-		padding-right: 0 !important; }
-	.pb-lg-0,
-	.py-lg-0 {
-		padding-bottom: 0 !important; }
-	.pl-lg-0,
-	.px-lg-0 {
-		padding-left: 0 !important; }
-	.p-lg-1 {
-		padding: 0.25rem !important; }
-	.pt-lg-1,
-	.py-lg-1 {
-		padding-top: 0.25rem !important; }
-	.pr-lg-1,
-	.px-lg-1 {
-		padding-right: 0.25rem !important; }
-	.pb-lg-1,
-	.py-lg-1 {
-		padding-bottom: 0.25rem !important; }
-	.pl-lg-1,
-	.px-lg-1 {
-		padding-left: 0.25rem !important; }
-	.p-lg-2 {
-		padding: 0.5rem !important; }
-	.pt-lg-2,
-	.py-lg-2 {
-		padding-top: 0.5rem !important; }
-	.pr-lg-2,
-	.px-lg-2 {
-		padding-right: 0.5rem !important; }
-	.pb-lg-2,
-	.py-lg-2 {
-		padding-bottom: 0.5rem !important; }
-	.pl-lg-2,
-	.px-lg-2 {
-		padding-left: 0.5rem !important; }
-	.p-lg-3 {
-		padding: 1rem !important; }
-	.pt-lg-3,
-	.py-lg-3 {
-		padding-top: 1rem !important; }
-	.pr-lg-3,
-	.px-lg-3 {
-		padding-right: 1rem !important; }
-	.pb-lg-3,
-	.py-lg-3 {
-		padding-bottom: 1rem !important; }
-	.pl-lg-3,
-	.px-lg-3 {
-		padding-left: 1rem !important; }
-	.p-lg-4 {
-		padding: 1.5rem !important; }
-	.pt-lg-4,
-	.py-lg-4 {
-		padding-top: 1.5rem !important; }
-	.pr-lg-4,
-	.px-lg-4 {
-		padding-right: 1.5rem !important; }
-	.pb-lg-4,
-	.py-lg-4 {
-		padding-bottom: 1.5rem !important; }
-	.pl-lg-4,
-	.px-lg-4 {
-		padding-left: 1.5rem !important; }
-	.p-lg-5 {
-		padding: 3rem !important; }
-	.pt-lg-5,
-	.py-lg-5 {
-		padding-top: 3rem !important; }
-	.pr-lg-5,
-	.px-lg-5 {
-		padding-right: 3rem !important; }
-	.pb-lg-5,
-	.py-lg-5 {
-		padding-bottom: 3rem !important; }
-	.pl-lg-5,
-	.px-lg-5 {
-		padding-left: 3rem !important; }
-	.m-lg-n1 {
-		margin: -0.25rem !important; }
-	.mt-lg-n1,
-	.my-lg-n1 {
-		margin-top: -0.25rem !important; }
-	.mr-lg-n1,
-	.mx-lg-n1 {
-		margin-right: -0.25rem !important; }
-	.mb-lg-n1,
-	.my-lg-n1 {
-		margin-bottom: -0.25rem !important; }
-	.ml-lg-n1,
-	.mx-lg-n1 {
-		margin-left: -0.25rem !important; }
-	.m-lg-n2 {
-		margin: -0.5rem !important; }
-	.mt-lg-n2,
-	.my-lg-n2 {
-		margin-top: -0.5rem !important; }
-	.mr-lg-n2,
-	.mx-lg-n2 {
-		margin-right: -0.5rem !important; }
-	.mb-lg-n2,
-	.my-lg-n2 {
-		margin-bottom: -0.5rem !important; }
-	.ml-lg-n2,
-	.mx-lg-n2 {
-		margin-left: -0.5rem !important; }
-	.m-lg-n3 {
-		margin: -1rem !important; }
-	.mt-lg-n3,
-	.my-lg-n3 {
-		margin-top: -1rem !important; }
-	.mr-lg-n3,
-	.mx-lg-n3 {
-		margin-right: -1rem !important; }
-	.mb-lg-n3,
-	.my-lg-n3 {
-		margin-bottom: -1rem !important; }
-	.ml-lg-n3,
-	.mx-lg-n3 {
-		margin-left: -1rem !important; }
-	.m-lg-n4 {
-		margin: -1.5rem !important; }
-	.mt-lg-n4,
-	.my-lg-n4 {
-		margin-top: -1.5rem !important; }
-	.mr-lg-n4,
-	.mx-lg-n4 {
-		margin-right: -1.5rem !important; }
-	.mb-lg-n4,
-	.my-lg-n4 {
-		margin-bottom: -1.5rem !important; }
-	.ml-lg-n4,
-	.mx-lg-n4 {
-		margin-left: -1.5rem !important; }
-	.m-lg-n5 {
-		margin: -3rem !important; }
-	.mt-lg-n5,
-	.my-lg-n5 {
-		margin-top: -3rem !important; }
-	.mr-lg-n5,
-	.mx-lg-n5 {
-		margin-right: -3rem !important; }
-	.mb-lg-n5,
-	.my-lg-n5 {
-		margin-bottom: -3rem !important; }
-	.ml-lg-n5,
-	.mx-lg-n5 {
-		margin-left: -3rem !important; }
-	.m-lg-auto {
-		margin: auto !important; }
-	.mt-lg-auto,
-	.my-lg-auto {
-		margin-top: auto !important; }
-	.mr-lg-auto,
-	.mx-lg-auto {
-		margin-right: auto !important; }
-	.mb-lg-auto,
-	.my-lg-auto {
-		margin-bottom: auto !important; }
-	.ml-lg-auto,
-	.mx-lg-auto {
-		margin-left: auto !important; } }
-
+  .m-lg-0 {
+    margin: 0 !important;
+  }
+  .mt-lg-0, .my-lg-0 {
+    margin-top: 0 !important;
+  }
+  .mr-lg-0, .mx-lg-0 {
+    margin-right: 0 !important;
+  }
+  .mb-lg-0, .my-lg-0 {
+    margin-bottom: 0 !important;
+  }
+  .ml-lg-0, .mx-lg-0 {
+    margin-left: 0 !important;
+  }
+  .m-lg-1 {
+    margin: 0.25rem !important;
+  }
+  .mt-lg-1, .my-lg-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mr-lg-1, .mx-lg-1 {
+    margin-right: 0.25rem !important;
+  }
+  .mb-lg-1, .my-lg-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .ml-lg-1, .mx-lg-1 {
+    margin-left: 0.25rem !important;
+  }
+  .m-lg-2 {
+    margin: 0.5rem !important;
+  }
+  .mt-lg-2, .my-lg-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mr-lg-2, .mx-lg-2 {
+    margin-right: 0.5rem !important;
+  }
+  .mb-lg-2, .my-lg-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .ml-lg-2, .mx-lg-2 {
+    margin-left: 0.5rem !important;
+  }
+  .m-lg-3 {
+    margin: 1rem !important;
+  }
+  .mt-lg-3, .my-lg-3 {
+    margin-top: 1rem !important;
+  }
+  .mr-lg-3, .mx-lg-3 {
+    margin-right: 1rem !important;
+  }
+  .mb-lg-3, .my-lg-3 {
+    margin-bottom: 1rem !important;
+  }
+  .ml-lg-3, .mx-lg-3 {
+    margin-left: 1rem !important;
+  }
+  .m-lg-4 {
+    margin: 1.5rem !important;
+  }
+  .mt-lg-4, .my-lg-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mr-lg-4, .mx-lg-4 {
+    margin-right: 1.5rem !important;
+  }
+  .mb-lg-4, .my-lg-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .ml-lg-4, .mx-lg-4 {
+    margin-left: 1.5rem !important;
+  }
+  .m-lg-5 {
+    margin: 3rem !important;
+  }
+  .mt-lg-5, .my-lg-5 {
+    margin-top: 3rem !important;
+  }
+  .mr-lg-5, .mx-lg-5 {
+    margin-right: 3rem !important;
+  }
+  .mb-lg-5, .my-lg-5 {
+    margin-bottom: 3rem !important;
+  }
+  .ml-lg-5, .mx-lg-5 {
+    margin-left: 3rem !important;
+  }
+  .p-lg-0 {
+    padding: 0 !important;
+  }
+  .pt-lg-0, .py-lg-0 {
+    padding-top: 0 !important;
+  }
+  .pr-lg-0, .px-lg-0 {
+    padding-right: 0 !important;
+  }
+  .pb-lg-0, .py-lg-0 {
+    padding-bottom: 0 !important;
+  }
+  .pl-lg-0, .px-lg-0 {
+    padding-left: 0 !important;
+  }
+  .p-lg-1 {
+    padding: 0.25rem !important;
+  }
+  .pt-lg-1, .py-lg-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pr-lg-1, .px-lg-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pb-lg-1, .py-lg-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pl-lg-1, .px-lg-1 {
+    padding-left: 0.25rem !important;
+  }
+  .p-lg-2 {
+    padding: 0.5rem !important;
+  }
+  .pt-lg-2, .py-lg-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pr-lg-2, .px-lg-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pb-lg-2, .py-lg-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pl-lg-2, .px-lg-2 {
+    padding-left: 0.5rem !important;
+  }
+  .p-lg-3 {
+    padding: 1rem !important;
+  }
+  .pt-lg-3, .py-lg-3 {
+    padding-top: 1rem !important;
+  }
+  .pr-lg-3, .px-lg-3 {
+    padding-right: 1rem !important;
+  }
+  .pb-lg-3, .py-lg-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pl-lg-3, .px-lg-3 {
+    padding-left: 1rem !important;
+  }
+  .p-lg-4 {
+    padding: 1.5rem !important;
+  }
+  .pt-lg-4, .py-lg-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pr-lg-4, .px-lg-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pb-lg-4, .py-lg-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pl-lg-4, .px-lg-4 {
+    padding-left: 1.5rem !important;
+  }
+  .p-lg-5 {
+    padding: 3rem !important;
+  }
+  .pt-lg-5, .py-lg-5 {
+    padding-top: 3rem !important;
+  }
+  .pr-lg-5, .px-lg-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-lg-5, .py-lg-5 {
+    padding-bottom: 3rem !important;
+  }
+  .pl-lg-5, .px-lg-5 {
+    padding-left: 3rem !important;
+  }
+  .m-lg-n1 {
+    margin: -0.25rem !important;
+  }
+  .mt-lg-n1, .my-lg-n1 {
+    margin-top: -0.25rem !important;
+  }
+  .mr-lg-n1, .mx-lg-n1 {
+    margin-right: -0.25rem !important;
+  }
+  .mb-lg-n1, .my-lg-n1 {
+    margin-bottom: -0.25rem !important;
+  }
+  .ml-lg-n1, .mx-lg-n1 {
+    margin-left: -0.25rem !important;
+  }
+  .m-lg-n2 {
+    margin: -0.5rem !important;
+  }
+  .mt-lg-n2, .my-lg-n2 {
+    margin-top: -0.5rem !important;
+  }
+  .mr-lg-n2, .mx-lg-n2 {
+    margin-right: -0.5rem !important;
+  }
+  .mb-lg-n2, .my-lg-n2 {
+    margin-bottom: -0.5rem !important;
+  }
+  .ml-lg-n2, .mx-lg-n2 {
+    margin-left: -0.5rem !important;
+  }
+  .m-lg-n3 {
+    margin: -1rem !important;
+  }
+  .mt-lg-n3, .my-lg-n3 {
+    margin-top: -1rem !important;
+  }
+  .mr-lg-n3, .mx-lg-n3 {
+    margin-right: -1rem !important;
+  }
+  .mb-lg-n3, .my-lg-n3 {
+    margin-bottom: -1rem !important;
+  }
+  .ml-lg-n3, .mx-lg-n3 {
+    margin-left: -1rem !important;
+  }
+  .m-lg-n4 {
+    margin: -1.5rem !important;
+  }
+  .mt-lg-n4, .my-lg-n4 {
+    margin-top: -1.5rem !important;
+  }
+  .mr-lg-n4, .mx-lg-n4 {
+    margin-right: -1.5rem !important;
+  }
+  .mb-lg-n4, .my-lg-n4 {
+    margin-bottom: -1.5rem !important;
+  }
+  .ml-lg-n4, .mx-lg-n4 {
+    margin-left: -1.5rem !important;
+  }
+  .m-lg-n5 {
+    margin: -3rem !important;
+  }
+  .mt-lg-n5, .my-lg-n5 {
+    margin-top: -3rem !important;
+  }
+  .mr-lg-n5, .mx-lg-n5 {
+    margin-right: -3rem !important;
+  }
+  .mb-lg-n5, .my-lg-n5 {
+    margin-bottom: -3rem !important;
+  }
+  .ml-lg-n5, .mx-lg-n5 {
+    margin-left: -3rem !important;
+  }
+  .m-lg-auto {
+    margin: auto !important;
+  }
+  .mt-lg-auto, .my-lg-auto {
+    margin-top: auto !important;
+  }
+  .mr-lg-auto, .mx-lg-auto {
+    margin-right: auto !important;
+  }
+  .mb-lg-auto, .my-lg-auto {
+    margin-bottom: auto !important;
+  }
+  .ml-lg-auto, .mx-lg-auto {
+    margin-left: auto !important;
+  }
+}
 @media (min-width: 1200px) {
-	.m-xl-0 {
-		margin: 0 !important; }
-	.mt-xl-0,
-	.my-xl-0 {
-		margin-top: 0 !important; }
-	.mr-xl-0,
-	.mx-xl-0 {
-		margin-right: 0 !important; }
-	.mb-xl-0,
-	.my-xl-0 {
-		margin-bottom: 0 !important; }
-	.ml-xl-0,
-	.mx-xl-0 {
-		margin-left: 0 !important; }
-	.m-xl-1 {
-		margin: 0.25rem !important; }
-	.mt-xl-1,
-	.my-xl-1 {
-		margin-top: 0.25rem !important; }
-	.mr-xl-1,
-	.mx-xl-1 {
-		margin-right: 0.25rem !important; }
-	.mb-xl-1,
-	.my-xl-1 {
-		margin-bottom: 0.25rem !important; }
-	.ml-xl-1,
-	.mx-xl-1 {
-		margin-left: 0.25rem !important; }
-	.m-xl-2 {
-		margin: 0.5rem !important; }
-	.mt-xl-2,
-	.my-xl-2 {
-		margin-top: 0.5rem !important; }
-	.mr-xl-2,
-	.mx-xl-2 {
-		margin-right: 0.5rem !important; }
-	.mb-xl-2,
-	.my-xl-2 {
-		margin-bottom: 0.5rem !important; }
-	.ml-xl-2,
-	.mx-xl-2 {
-		margin-left: 0.5rem !important; }
-	.m-xl-3 {
-		margin: 1rem !important; }
-	.mt-xl-3,
-	.my-xl-3 {
-		margin-top: 1rem !important; }
-	.mr-xl-3,
-	.mx-xl-3 {
-		margin-right: 1rem !important; }
-	.mb-xl-3,
-	.my-xl-3 {
-		margin-bottom: 1rem !important; }
-	.ml-xl-3,
-	.mx-xl-3 {
-		margin-left: 1rem !important; }
-	.m-xl-4 {
-		margin: 1.5rem !important; }
-	.mt-xl-4,
-	.my-xl-4 {
-		margin-top: 1.5rem !important; }
-	.mr-xl-4,
-	.mx-xl-4 {
-		margin-right: 1.5rem !important; }
-	.mb-xl-4,
-	.my-xl-4 {
-		margin-bottom: 1.5rem !important; }
-	.ml-xl-4,
-	.mx-xl-4 {
-		margin-left: 1.5rem !important; }
-	.m-xl-5 {
-		margin: 3rem !important; }
-	.mt-xl-5,
-	.my-xl-5 {
-		margin-top: 3rem !important; }
-	.mr-xl-5,
-	.mx-xl-5 {
-		margin-right: 3rem !important; }
-	.mb-xl-5,
-	.my-xl-5 {
-		margin-bottom: 3rem !important; }
-	.ml-xl-5,
-	.mx-xl-5 {
-		margin-left: 3rem !important; }
-	.p-xl-0 {
-		padding: 0 !important; }
-	.pt-xl-0,
-	.py-xl-0 {
-		padding-top: 0 !important; }
-	.pr-xl-0,
-	.px-xl-0 {
-		padding-right: 0 !important; }
-	.pb-xl-0,
-	.py-xl-0 {
-		padding-bottom: 0 !important; }
-	.pl-xl-0,
-	.px-xl-0 {
-		padding-left: 0 !important; }
-	.p-xl-1 {
-		padding: 0.25rem !important; }
-	.pt-xl-1,
-	.py-xl-1 {
-		padding-top: 0.25rem !important; }
-	.pr-xl-1,
-	.px-xl-1 {
-		padding-right: 0.25rem !important; }
-	.pb-xl-1,
-	.py-xl-1 {
-		padding-bottom: 0.25rem !important; }
-	.pl-xl-1,
-	.px-xl-1 {
-		padding-left: 0.25rem !important; }
-	.p-xl-2 {
-		padding: 0.5rem !important; }
-	.pt-xl-2,
-	.py-xl-2 {
-		padding-top: 0.5rem !important; }
-	.pr-xl-2,
-	.px-xl-2 {
-		padding-right: 0.5rem !important; }
-	.pb-xl-2,
-	.py-xl-2 {
-		padding-bottom: 0.5rem !important; }
-	.pl-xl-2,
-	.px-xl-2 {
-		padding-left: 0.5rem !important; }
-	.p-xl-3 {
-		padding: 1rem !important; }
-	.pt-xl-3,
-	.py-xl-3 {
-		padding-top: 1rem !important; }
-	.pr-xl-3,
-	.px-xl-3 {
-		padding-right: 1rem !important; }
-	.pb-xl-3,
-	.py-xl-3 {
-		padding-bottom: 1rem !important; }
-	.pl-xl-3,
-	.px-xl-3 {
-		padding-left: 1rem !important; }
-	.p-xl-4 {
-		padding: 1.5rem !important; }
-	.pt-xl-4,
-	.py-xl-4 {
-		padding-top: 1.5rem !important; }
-	.pr-xl-4,
-	.px-xl-4 {
-		padding-right: 1.5rem !important; }
-	.pb-xl-4,
-	.py-xl-4 {
-		padding-bottom: 1.5rem !important; }
-	.pl-xl-4,
-	.px-xl-4 {
-		padding-left: 1.5rem !important; }
-	.p-xl-5 {
-		padding: 3rem !important; }
-	.pt-xl-5,
-	.py-xl-5 {
-		padding-top: 3rem !important; }
-	.pr-xl-5,
-	.px-xl-5 {
-		padding-right: 3rem !important; }
-	.pb-xl-5,
-	.py-xl-5 {
-		padding-bottom: 3rem !important; }
-	.pl-xl-5,
-	.px-xl-5 {
-		padding-left: 3rem !important; }
-	.m-xl-n1 {
-		margin: -0.25rem !important; }
-	.mt-xl-n1,
-	.my-xl-n1 {
-		margin-top: -0.25rem !important; }
-	.mr-xl-n1,
-	.mx-xl-n1 {
-		margin-right: -0.25rem !important; }
-	.mb-xl-n1,
-	.my-xl-n1 {
-		margin-bottom: -0.25rem !important; }
-	.ml-xl-n1,
-	.mx-xl-n1 {
-		margin-left: -0.25rem !important; }
-	.m-xl-n2 {
-		margin: -0.5rem !important; }
-	.mt-xl-n2,
-	.my-xl-n2 {
-		margin-top: -0.5rem !important; }
-	.mr-xl-n2,
-	.mx-xl-n2 {
-		margin-right: -0.5rem !important; }
-	.mb-xl-n2,
-	.my-xl-n2 {
-		margin-bottom: -0.5rem !important; }
-	.ml-xl-n2,
-	.mx-xl-n2 {
-		margin-left: -0.5rem !important; }
-	.m-xl-n3 {
-		margin: -1rem !important; }
-	.mt-xl-n3,
-	.my-xl-n3 {
-		margin-top: -1rem !important; }
-	.mr-xl-n3,
-	.mx-xl-n3 {
-		margin-right: -1rem !important; }
-	.mb-xl-n3,
-	.my-xl-n3 {
-		margin-bottom: -1rem !important; }
-	.ml-xl-n3,
-	.mx-xl-n3 {
-		margin-left: -1rem !important; }
-	.m-xl-n4 {
-		margin: -1.5rem !important; }
-	.mt-xl-n4,
-	.my-xl-n4 {
-		margin-top: -1.5rem !important; }
-	.mr-xl-n4,
-	.mx-xl-n4 {
-		margin-right: -1.5rem !important; }
-	.mb-xl-n4,
-	.my-xl-n4 {
-		margin-bottom: -1.5rem !important; }
-	.ml-xl-n4,
-	.mx-xl-n4 {
-		margin-left: -1.5rem !important; }
-	.m-xl-n5 {
-		margin: -3rem !important; }
-	.mt-xl-n5,
-	.my-xl-n5 {
-		margin-top: -3rem !important; }
-	.mr-xl-n5,
-	.mx-xl-n5 {
-		margin-right: -3rem !important; }
-	.mb-xl-n5,
-	.my-xl-n5 {
-		margin-bottom: -3rem !important; }
-	.ml-xl-n5,
-	.mx-xl-n5 {
-		margin-left: -3rem !important; }
-	.m-xl-auto {
-		margin: auto !important; }
-	.mt-xl-auto,
-	.my-xl-auto {
-		margin-top: auto !important; }
-	.mr-xl-auto,
-	.mx-xl-auto {
-		margin-right: auto !important; }
-	.mb-xl-auto,
-	.my-xl-auto {
-		margin-bottom: auto !important; }
-	.ml-xl-auto,
-	.mx-xl-auto {
-		margin-left: auto !important; } }
+  .m-xl-0 {
+    margin: 0 !important;
+  }
+  .mt-xl-0, .my-xl-0 {
+    margin-top: 0 !important;
+  }
+  .mr-xl-0, .mx-xl-0 {
+    margin-right: 0 !important;
+  }
+  .mb-xl-0, .my-xl-0 {
+    margin-bottom: 0 !important;
+  }
+  .ml-xl-0, .mx-xl-0 {
+    margin-left: 0 !important;
+  }
+  .m-xl-1 {
+    margin: 0.25rem !important;
+  }
+  .mt-xl-1, .my-xl-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mr-xl-1, .mx-xl-1 {
+    margin-right: 0.25rem !important;
+  }
+  .mb-xl-1, .my-xl-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .ml-xl-1, .mx-xl-1 {
+    margin-left: 0.25rem !important;
+  }
+  .m-xl-2 {
+    margin: 0.5rem !important;
+  }
+  .mt-xl-2, .my-xl-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mr-xl-2, .mx-xl-2 {
+    margin-right: 0.5rem !important;
+  }
+  .mb-xl-2, .my-xl-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .ml-xl-2, .mx-xl-2 {
+    margin-left: 0.5rem !important;
+  }
+  .m-xl-3 {
+    margin: 1rem !important;
+  }
+  .mt-xl-3, .my-xl-3 {
+    margin-top: 1rem !important;
+  }
+  .mr-xl-3, .mx-xl-3 {
+    margin-right: 1rem !important;
+  }
+  .mb-xl-3, .my-xl-3 {
+    margin-bottom: 1rem !important;
+  }
+  .ml-xl-3, .mx-xl-3 {
+    margin-left: 1rem !important;
+  }
+  .m-xl-4 {
+    margin: 1.5rem !important;
+  }
+  .mt-xl-4, .my-xl-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mr-xl-4, .mx-xl-4 {
+    margin-right: 1.5rem !important;
+  }
+  .mb-xl-4, .my-xl-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .ml-xl-4, .mx-xl-4 {
+    margin-left: 1.5rem !important;
+  }
+  .m-xl-5 {
+    margin: 3rem !important;
+  }
+  .mt-xl-5, .my-xl-5 {
+    margin-top: 3rem !important;
+  }
+  .mr-xl-5, .mx-xl-5 {
+    margin-right: 3rem !important;
+  }
+  .mb-xl-5, .my-xl-5 {
+    margin-bottom: 3rem !important;
+  }
+  .ml-xl-5, .mx-xl-5 {
+    margin-left: 3rem !important;
+  }
+  .p-xl-0 {
+    padding: 0 !important;
+  }
+  .pt-xl-0, .py-xl-0 {
+    padding-top: 0 !important;
+  }
+  .pr-xl-0, .px-xl-0 {
+    padding-right: 0 !important;
+  }
+  .pb-xl-0, .py-xl-0 {
+    padding-bottom: 0 !important;
+  }
+  .pl-xl-0, .px-xl-0 {
+    padding-left: 0 !important;
+  }
+  .p-xl-1 {
+    padding: 0.25rem !important;
+  }
+  .pt-xl-1, .py-xl-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pr-xl-1, .px-xl-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pb-xl-1, .py-xl-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pl-xl-1, .px-xl-1 {
+    padding-left: 0.25rem !important;
+  }
+  .p-xl-2 {
+    padding: 0.5rem !important;
+  }
+  .pt-xl-2, .py-xl-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pr-xl-2, .px-xl-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pb-xl-2, .py-xl-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pl-xl-2, .px-xl-2 {
+    padding-left: 0.5rem !important;
+  }
+  .p-xl-3 {
+    padding: 1rem !important;
+  }
+  .pt-xl-3, .py-xl-3 {
+    padding-top: 1rem !important;
+  }
+  .pr-xl-3, .px-xl-3 {
+    padding-right: 1rem !important;
+  }
+  .pb-xl-3, .py-xl-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pl-xl-3, .px-xl-3 {
+    padding-left: 1rem !important;
+  }
+  .p-xl-4 {
+    padding: 1.5rem !important;
+  }
+  .pt-xl-4, .py-xl-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pr-xl-4, .px-xl-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pb-xl-4, .py-xl-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pl-xl-4, .px-xl-4 {
+    padding-left: 1.5rem !important;
+  }
+  .p-xl-5 {
+    padding: 3rem !important;
+  }
+  .pt-xl-5, .py-xl-5 {
+    padding-top: 3rem !important;
+  }
+  .pr-xl-5, .px-xl-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-xl-5, .py-xl-5 {
+    padding-bottom: 3rem !important;
+  }
+  .pl-xl-5, .px-xl-5 {
+    padding-left: 3rem !important;
+  }
+  .m-xl-n1 {
+    margin: -0.25rem !important;
+  }
+  .mt-xl-n1, .my-xl-n1 {
+    margin-top: -0.25rem !important;
+  }
+  .mr-xl-n1, .mx-xl-n1 {
+    margin-right: -0.25rem !important;
+  }
+  .mb-xl-n1, .my-xl-n1 {
+    margin-bottom: -0.25rem !important;
+  }
+  .ml-xl-n1, .mx-xl-n1 {
+    margin-left: -0.25rem !important;
+  }
+  .m-xl-n2 {
+    margin: -0.5rem !important;
+  }
+  .mt-xl-n2, .my-xl-n2 {
+    margin-top: -0.5rem !important;
+  }
+  .mr-xl-n2, .mx-xl-n2 {
+    margin-right: -0.5rem !important;
+  }
+  .mb-xl-n2, .my-xl-n2 {
+    margin-bottom: -0.5rem !important;
+  }
+  .ml-xl-n2, .mx-xl-n2 {
+    margin-left: -0.5rem !important;
+  }
+  .m-xl-n3 {
+    margin: -1rem !important;
+  }
+  .mt-xl-n3, .my-xl-n3 {
+    margin-top: -1rem !important;
+  }
+  .mr-xl-n3, .mx-xl-n3 {
+    margin-right: -1rem !important;
+  }
+  .mb-xl-n3, .my-xl-n3 {
+    margin-bottom: -1rem !important;
+  }
+  .ml-xl-n3, .mx-xl-n3 {
+    margin-left: -1rem !important;
+  }
+  .m-xl-n4 {
+    margin: -1.5rem !important;
+  }
+  .mt-xl-n4, .my-xl-n4 {
+    margin-top: -1.5rem !important;
+  }
+  .mr-xl-n4, .mx-xl-n4 {
+    margin-right: -1.5rem !important;
+  }
+  .mb-xl-n4, .my-xl-n4 {
+    margin-bottom: -1.5rem !important;
+  }
+  .ml-xl-n4, .mx-xl-n4 {
+    margin-left: -1.5rem !important;
+  }
+  .m-xl-n5 {
+    margin: -3rem !important;
+  }
+  .mt-xl-n5, .my-xl-n5 {
+    margin-top: -3rem !important;
+  }
+  .mr-xl-n5, .mx-xl-n5 {
+    margin-right: -3rem !important;
+  }
+  .mb-xl-n5, .my-xl-n5 {
+    margin-bottom: -3rem !important;
+  }
+  .ml-xl-n5, .mx-xl-n5 {
+    margin-left: -3rem !important;
+  }
+  .m-xl-auto {
+    margin: auto !important;
+  }
+  .mt-xl-auto, .my-xl-auto {
+    margin-top: auto !important;
+  }
+  .mr-xl-auto, .mx-xl-auto {
+    margin-right: auto !important;
+  }
+  .mb-xl-auto, .my-xl-auto {
+    margin-bottom: auto !important;
+  }
+  .ml-xl-auto, .mx-xl-auto {
+    margin-left: auto !important;
+  }
+}
 /* bs-4 spacing end */

--- a/www/templates/joomla/css/custom.css
+++ b/www/templates/joomla/css/custom.css
@@ -1,4 +1,4 @@
-/* EasBlog */
+/* EasyBlog - General Style Overrides*/
 div#eb {
     clear: both;
 }
@@ -64,15 +64,15 @@ Added: 2020-04-20 - Mark Lee / WilcoA
 Added 2021-03-19 - Mark Lee / WilcoA (PR raised by Patrick Jackson)
 Aligns continue reading buttons across the issue category view
 */
-#eb .eb-mag-grids__item > div {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+#eb .eb-mag-grids__item > div, #eb .eb-blog-grid__content { /* Second class applies to issues layout */
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
-#eb .eb-mag .eb-mag-body {
-    display: flex;
-    height: 100%;
-    flex-direction: column;
+#eb .eb-mag .eb-mag-body, #eb .eb-blog-grid__body { /* Second class applies to issues layout */
+  display: flex;
+  height: 100%;
+  flex-direction: column;
 }
 #eb .eb-mag .eb-mag-body p {
     flex-grow: 1;
@@ -81,6 +81,112 @@ Aligns continue reading buttons across the issue category view
 #eb .eb-mag .eb-mag-body p:empty {
     display: none;
 }
+
+#eb .eb-mag-grids .eb-mag-blog-image, #eb .eb-blog-grid-image {
+    background-size: contain; /* Changes it from cover which cropped the images */
+    padding-bottom: 48%; /* Was 60% for cover */
+}
+/* EasyBlog Article styles
+- proposed in https://github.com/joomla/magazine.joomla.org/issues/15 by @coolcat-creations
+- Tweaked by @particthistle April 2021
+*/
+#eb .eb-mag .eb-mag-body, #eb .eb-blog-grid__body {
+  font-size: 16px;
+  line-height: 135%;
+}
+#eb .eb-mag .eb-mag-grids__item, #eb .eb-blog-grid__item {
+  padding: 15px;
+}
+#eb .magazine-btn-more, #eb .eb-post-more .btn {
+  font-size: 16px;
+  border: none;
+  background: #1e88e5 !important;
+  color: #fff !important;
+  font-weight: normal;
+  width: 100%;
+}
+#eb .magazine-btn-more:hover, #eb .eb-post-more .btn:hover {
+  background-color: #1773c4 !important;
+}
+#eb .eb-mag a {
+  color: inherit;
+}
+#eb a:link {
+  text-decoration: none;
+  text-decoration-line: none;
+  text-decoration-style: solid;
+  text-decoration-color: currentcolor;
+  text-decoration-thickness: auto;
+}
+a {
+  color: #08c;
+  text-decoration: none;
+  text-decoration-line: none;
+  text-decoration-style: solid;
+  text-decoration-color: currentcolor;
+  text-decoration-thickness: auto;
+}
+#eb .eb-mag-title, #eb .eb-blog-grid__title {
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 130%;
+  color: #2B3455 !important;
+}
+#eb .eb-mag-thumb {
+  margin: 10px 0;
+  max-height: 160px;
+}
+/* EasyBlog Article styles
+- proposed in https://github.com/joomla/magazine.joomla.org/issues/16 by @coolcat-creations
+- Tweaked by @particthistle April 2021
+*/
+.eb-entry-body {
+  font-size: 16px;
+  line-height: 140%;
+  padding: 0 100px;
+}
+.eb-entry-body .eb-image.eb-post-thumb {
+  max-width: auto;
+  margin: 0 -100px;
+}
+#eb h1 {
+  color: #2E3657;
+  font-size: 36px;
+}
+#eb h2, #eb h3, #eb h4, #eb h5, #eb h6 {
+  margin: 50px 0 20px;
+  color: #E94F34;
+}
+.eb-entry-meta.text-muted a {
+  color: #EA7C55;
+  text-decoration: underline !important;
+}
+.es-post-state {
+  padding: 0 100px;
+}
+.eb-entry-head {
+  padding: 20px 100px;
+}
+#eb .eb-reading-indicator {
+  padding: 4px 8px;
+  display: inline-block;
+  background-color: #1e88e5;
+  color: #fff;
+}
+
+@media(max-width: 768px) { /* Mobile styles applying to above April 2021 improvements */
+    
+    #eb .eb-mag .eb-mag-grids {
+        display: grid;
+        grid-template-columns: auto;
+        margin-bottom: 8px;
+    }
+    
+    #eb .eb-blog-grid__item { /* Displays flex columns at single column on mobile vs 3 columns */
+        flex: 0 0 100%;
+    }
+} /* End mobile styles */
+
 
 /* 
 Added Patrick Jackson 2021-03-10

--- a/www/templates/joomla/css/custom.css
+++ b/www/templates/joomla/css/custom.css
@@ -152,10 +152,10 @@ a {
 }
 #eb h2, #eb h3, #eb h4, #eb h5, #eb h6 {
   margin: 50px 0 20px;
-  color: #E94F34;
+  color: #5091cd;
 }
 .eb-entry-meta.text-muted a {
-  color: #EA7C55;
+  color: #5091cd;
   text-decoration: underline !important;
 }
 .es-post-state {


### PR DESCRIPTION
See PR and issues #15 and #16 for more details on suggested changes by @coolcat-creations

Additions outside #15 and #16
- Continue Reading buttons aligned extending #24 (will be in PR)
- Also changed images from cover to contain so the article thumbnails now show as full images vs cropping.
- Changed mobile columns from 3 to 1 so now mobile readers get a cleaner view of issues in one column.

Summary of changes from #15:
- Font size 16px for articles and issues article list
- Suggested formatting additionally applied to the issues page instead of just the home page.
- Buttons blue instead of green to match existing magazine template flow in other sections

Summary of changes from #16:
- Base font size only changing to 16px not 18px.
- Padding on article dropped back to 100px from 145px proposed.
- .eb-entry-body .eb-image.eb-post-thumb set to restore the article lead image back to full width of the layout.
- Reading indicator button set to #1e88e5 to match other buttons on the page and 3px radius added.

